### PR TITLE
Revamp portfolio UI with modern design improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "styled-components": "^5.3.5",
     "typewriter-effect": "^2.19.0",
     "react-parallax-tilt": "^1.7.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "lenis": "^1.1.14"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-scroll": "^1.8.7",
     "styled-components": "^5.3.5",
     "typewriter-effect": "^2.19.0",
+    "react-parallax-tilt": "^1.7.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -13,12 +13,13 @@ import Contact from "./components/Contact";
 import Footer from "./components/Footer";
 import Experience from "./components/Experience";
 import Education from "./components/Education";
-import Certificates from "./components/Certificates"; // Import the new component
+import Certificates from "./components/Certificates";
 import ProjectDetails from "./components/ProjectDetails";
 import ScrollToTop from "./components/ScrollToTop";
 import AdminApp from "./admin/AdminApp";
 import styled from "styled-components";
 import GlobalStyles from "./styles/GlobalStyles";
+import { AnimatePresence } from "framer-motion";
 import { getAnalytics, logEvent } from "firebase/analytics";
 import { app } from "./services/firebase";
 
@@ -26,7 +27,7 @@ const Body = styled.div`
   background-color: ${({ theme }) => theme.bg};
   width: 100%;
   overflow-x: hidden;
-  transition: all 0.3s ease-in-out;
+  transition: background-color 0.3s ease-in-out;
 `;
 
 const Wrapper = styled.div`
@@ -41,7 +42,6 @@ const Wrapper = styled.div`
       ${({ theme }) => theme.gradients.wrapper.blueLight} 100%
   );
   width: 100%;
-  clip-path: polygon(0 0, 100% 0, 100% 100%, 30% 98%, 0 100%);
 `;
 
 const analytics = getAnalytics(app);
@@ -105,17 +105,19 @@ function App() {
                 <Contact />
               </Wrapper>
               <Footer />
-              {openModal.state && (
-                <ProjectDetails
-                  openModal={openModal}
-                  setOpenModal={(newModalState) => {
-                    setOpenModal(newModalState);
-                    if (!newModalState.state) {
-                      setTimeout(() => { document.body.style.overflow = ''; }, 100);
-                    }
-                  }}
-                />
-              )}
+              <AnimatePresence>
+                {openModal.state && (
+                  <ProjectDetails
+                    openModal={openModal}
+                    setOpenModal={(newModalState) => {
+                      setOpenModal(newModalState);
+                      if (!newModalState.state) {
+                        setTimeout(() => { document.body.style.overflow = ''; }, 100);
+                      }
+                    }}
+                  />
+                )}
+              </AnimatePresence>
             </Body>
           </>
         )}

--- a/src/App.js
+++ b/src/App.js
@@ -123,7 +123,7 @@ function App() {
               <SectionDivider from="bg" to="card_light" flip />
               <Certificates />
               <Contact />
-              <Footer />
+              <Footer onEasterEgg={() => setShowTerminal(true)} />
               <AnimatePresence>
                 {openModal.state && (
                   <ProjectDetails

--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ import GlobalStyles from "./styles/GlobalStyles";
 import SectionDivider from "./components/SectionDivider";
 import CursorSpotlight from "./components/CursorSpotlight";
 import { AnimatePresence } from "framer-motion";
+import useSmoothScroll from "./hooks/useSmoothScroll";
 import { getAnalytics, logEvent } from "firebase/analytics";
 import { app } from "./services/firebase";
 
@@ -39,6 +40,7 @@ function App() {
   // State management
   const [darkMode, setDarkMode] = useState(true);
   const [openModal, setOpenModal] = useState({ state: false, project: null });
+  useSmoothScroll();
 
   // Dark mode from user preference
   useEffect(() => {

--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import ScrollToTop from "./components/ScrollToTop";
 import AdminApp from "./admin/AdminApp";
 import styled from "styled-components";
 import GlobalStyles from "./styles/GlobalStyles";
+import SectionDivider from "./components/SectionDivider";
 import { AnimatePresence } from "framer-motion";
 import { getAnalytics, logEvent } from "firebase/analytics";
 import { app } from "./services/firebase";
@@ -30,19 +31,6 @@ const Body = styled.div`
   transition: background-color 0.3s ease-in-out;
 `;
 
-const Wrapper = styled.div`
-  background: linear-gradient(
-      38.73deg,
-      ${({ theme }) => theme.gradients.wrapper.pinkLight} 0%,
-      ${({ theme }) => theme.gradients.wrapper.pinkZero} 50%
-  ),
-  linear-gradient(
-      141.27deg,
-      ${({ theme }) => theme.gradients.wrapper.blueZero} 50%,
-      ${({ theme }) => theme.gradients.wrapper.blueLight} 100%
-  );
-  width: 100%;
-`;
 
 const analytics = getAnalytics(app);
 
@@ -94,16 +82,16 @@ function App() {
             <Body>
               <ScrollToTop />
               <HeroSection />
-              <Wrapper>
-                <Skills />
-                <Experience />
-              </Wrapper>
+              <SectionDivider from="card_light" to="bg" />
+              <Skills />
+              <SectionDivider from="bg" to="card_light" flip />
+              <Experience />
+              <SectionDivider from="card_light" to="bg" />
               <Projects openModal={openModal} setOpenModal={setOpenModal} />
-              <Wrapper>
-                <Education />
-                <Certificates />
-                <Contact />
-              </Wrapper>
+              <Education />
+              <SectionDivider from="bg" to="card_light" flip />
+              <Certificates />
+              <Contact />
               <Footer />
               <AnimatePresence>
                 {openModal.state && (

--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import SectionDivider from "./components/SectionDivider";
 import CursorSpotlight from "./components/CursorSpotlight";
 import IntroSplash, { shouldShowSplash } from "./components/IntroSplash";
 import NoiseTexture from "./components/NoiseTexture";
+import Terminal from "./components/Terminal";
 import { AnimatePresence } from "framer-motion";
 import useSmoothScroll from "./hooks/useSmoothScroll";
 import { getAnalytics, logEvent } from "firebase/analytics";
@@ -43,7 +44,27 @@ function App() {
   const [darkMode, setDarkMode] = useState(true);
   const [openModal, setOpenModal] = useState({ state: false, project: null });
   const [showSplash, setShowSplash] = useState(shouldShowSplash);
+  const [showTerminal, setShowTerminal] = useState(false);
   useSmoothScroll();
+
+  /* Konami code: ↑↑↓↓←→←→BA */
+  useEffect(() => {
+    const KONAMI = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
+    let idx = 0;
+    const handler = (e) => {
+      if (e.key === KONAMI[idx]) {
+        idx++;
+        if (idx === KONAMI.length) {
+          setShowTerminal(true);
+          idx = 0;
+        }
+      } else {
+        idx = e.key === KONAMI[0] ? 1 : 0;
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   // Dark mode from user preference
   useEffect(() => {
@@ -85,6 +106,7 @@ function App() {
         ) : (
           <>
             {showSplash && <IntroSplash onDone={() => setShowSplash(false)} />}
+            {showTerminal && <Terminal onClose={() => setShowTerminal(false)} />}
             <NoiseTexture />
             <CursorSpotlight darkMode={darkMode} />
             <Navbar darkMode={darkMode} toggleDarkMode={toggleDarkMode} />

--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import AdminApp from "./admin/AdminApp";
 import styled from "styled-components";
 import GlobalStyles from "./styles/GlobalStyles";
 import SectionDivider from "./components/SectionDivider";
+import CursorSpotlight from "./components/CursorSpotlight";
 import { AnimatePresence } from "framer-motion";
 import { getAnalytics, logEvent } from "firebase/analytics";
 import { app } from "./services/firebase";
@@ -78,6 +79,7 @@ function App() {
           <AdminApp />
         ) : (
           <>
+            <CursorSpotlight darkMode={darkMode} />
             <Navbar darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
             <Body>
               <ScrollToTop />

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ import { app } from "./services/firebase";
 const Body = styled.div`
   background-color: ${({ theme }) => theme.bg};
   width: 100%;
-  overflow-x: hidden;
+  overflow-x: clip;
   transition: background-color 0.3s ease-in-out;
 `;
 

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,8 @@ import styled from "styled-components";
 import GlobalStyles from "./styles/GlobalStyles";
 import SectionDivider from "./components/SectionDivider";
 import CursorSpotlight from "./components/CursorSpotlight";
+import IntroSplash, { shouldShowSplash } from "./components/IntroSplash";
+import NoiseTexture from "./components/NoiseTexture";
 import { AnimatePresence } from "framer-motion";
 import useSmoothScroll from "./hooks/useSmoothScroll";
 import { getAnalytics, logEvent } from "firebase/analytics";
@@ -40,6 +42,7 @@ function App() {
   // State management
   const [darkMode, setDarkMode] = useState(true);
   const [openModal, setOpenModal] = useState({ state: false, project: null });
+  const [showSplash, setShowSplash] = useState(shouldShowSplash);
   useSmoothScroll();
 
   // Dark mode from user preference
@@ -81,6 +84,8 @@ function App() {
           <AdminApp />
         ) : (
           <>
+            {showSplash && <IntroSplash onDone={() => setShowSplash(false)} />}
+            <NoiseTexture />
             <CursorSpotlight darkMode={darkMode} />
             <Navbar darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
             <Body>

--- a/src/components/Cards/EducationCard.jsx
+++ b/src/components/Cards/EducationCard.jsx
@@ -1,20 +1,8 @@
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
-import { motion } from 'framer-motion';
+import styled from 'styled-components';
 import { FaCalendarAlt, FaGraduationCap, FaAward, FaMapMarkerAlt, FaLink } from 'react-icons/fa';
 
-const fadeIn = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
-
-const Card = styled(motion.div)`
+const Card = styled.div`
   width: 100%;
   border-radius: 16px;
   padding: 20px 30px;
@@ -24,18 +12,17 @@ const Card = styled(motion.div)`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  transition: all 0.3s ease-in-out;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out, border-color 0.3s ease-in-out;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
   background-color: ${({ theme }) => theme.card};
   border: 1px solid ${({ theme }) => `${theme.primary}30`};
-  animation: ${fadeIn} 0.5s ease-in-out;
-  
+
   &:hover {
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
-    transform: translateY(-5px);
-    border: 1px solid ${({ theme }) => theme.primary};
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.14);
+    transform: translateY(-4px);
+    border-color: ${({ theme }) => theme.primary};
   }
-  
+
   @media (max-width: 768px) {
     padding: 16px;
     gap: 8px;

--- a/src/components/Cards/EducationCard.jsx
+++ b/src/components/Cards/EducationCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { FaCalendarAlt, FaGraduationCap, FaAward, FaMapMarkerAlt, FaLink } from 'react-icons/fa';
 
 const Card = styled.div`
@@ -181,7 +181,7 @@ const WebsiteLink = styled.a`
 `;
 
 const EducationCard = ({ education }) => {
-    // Extract city from the school name if it contains a comma
+    const theme = useTheme();
     const schoolParts = education.school.split(',');
     const schoolName = schoolParts[0];
     const schoolLocation = schoolParts.length > 1 ? schoolParts.slice(1).join(',').trim() : '';
@@ -218,7 +218,7 @@ const EducationCard = ({ education }) => {
 
             {education.grade && (
                 <GradeContainer>
-                    <FaAward size={16} color="#854CE6" />
+                    <FaAward size={16} color={theme.primary} />
                     <GradeLabel>Achievement:</GradeLabel>
                     <GradeValue>{education.grade}</GradeValue>
                 </GradeContainer>

--- a/src/components/Cards/ExperienceCard.jsx
+++ b/src/components/Cards/ExperienceCard.jsx
@@ -105,7 +105,7 @@ const CompanyLink = styled.a`
     display: flex;
     align-items: center;
     gap: 6px;
-    transition: all 0.3s ease;
+    transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out, transform 0.25s ease-in-out;
 
     &:hover {
         text-decoration: underline;
@@ -172,7 +172,7 @@ const Skill = styled.div`
     background-color: ${({ theme }) => `${theme.primary}20`};
     padding: 6px 14px;
     border-radius: 20px;
-    transition: all 0.3s ease-in-out;
+    transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out, transform 0.25s ease-in-out;
 
     &:hover {
         background-color: ${({ theme }) => `${theme.primary}40`};

--- a/src/components/Cards/ExperienceCard.jsx
+++ b/src/components/Cards/ExperienceCard.jsx
@@ -1,20 +1,8 @@
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
-import { motion } from 'framer-motion';
+import styled from 'styled-components';
 import { FaCalendarAlt, FaMapMarkerAlt, FaExternalLinkAlt, FaGooglePlay, FaAppStore, FaGithub, FaGlobe } from 'react-icons/fa';
 
-const fadeIn = keyframes`
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-`;
-
-const Card = styled(motion.div)`
+const Card = styled.div`
     width: 100%;
     border-radius: 16px;
     padding: 20px 30px;
@@ -24,16 +12,15 @@ const Card = styled(motion.div)`
     display: flex;
     flex-direction: column;
     gap: 12px;
-    transition: all 0.3s ease-in-out;
-    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out, border-color 0.3s ease-in-out;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
     background-color: ${({ theme }) => theme.card};
     border: 1px solid ${({ theme }) => `${theme.primary}30`};
-    animation: ${fadeIn} 0.5s ease-in-out;
 
     &:hover {
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
-        transform: translateY(-5px);
-        border: 1px solid ${({ theme }) => theme.primary};
+        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.14);
+        transform: translateY(-4px);
+        border-color: ${({ theme }) => theme.primary};
     }
 
     @media (max-width: 768px) {

--- a/src/components/Cards/ProjectCards.jsx
+++ b/src/components/Cards/ProjectCards.jsx
@@ -1,190 +1,225 @@
 import React from "react";
 import styled from "styled-components";
 
-const ImageWrapper = styled.div`
+/* ─── Image area ─── */
+
+const ImageArea = styled.div`
   position: relative;
   width: 100%;
-  height: 180px;
-  border-radius: 10px;
+  height: 200px;
   overflow: hidden;
-  box-shadow: 0 0 16px 2px rgba(0, 0, 0, 0.3);
+  border-radius: 12px 12px 0 0;
   flex-shrink: 0;
 `;
 
-const Image = styled.img`
+const Img = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
-  background-color: ${({ theme }) => theme.white};
-  transition: transform 0.3s ease-in-out;
+  display: block;
+  transition: transform 0.4s ease;
 `;
 
-const HoverOverlay = styled.div`
+/* gradient sits over the image and shows the title */
+const ImageGradient = styled.div`
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.72) 0%,
+    rgba(0, 0, 0, 0.1) 55%,
+    transparent 100%
+  );
+`;
+
+const ImageTitle = styled.div`
+  position: absolute;
+  bottom: 12px;
+  left: 14px;
+  right: 14px;
+  color: #fff;
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.3;
+  /* clamp to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+const CategoryBadge = styled.span`
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 3px 10px;
+  border-radius: 50px;
+  text-transform: uppercase;
+`;
+
+const ViewBadge = styled.div`
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
   opacity: 0;
-  transition: opacity 0.3s ease-in-out;
-  border-radius: 10px;
+  transition: opacity 0.25s ease;
+  border-radius: 12px 12px 0 0;
 `;
 
-const OverlayText = styled.span`
+const ViewLabel = styled.span`
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   color: #fff;
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 600;
-  letter-spacing: 0.5px;
+  padding: 8px 20px;
+  border-radius: 50px;
+  letter-spacing: 0.3px;
 `;
 
-const Card = styled.div`
-  width: 330px;
-  min-height: 420px;
-  background-color: ${({ theme }) => theme.card};
-  cursor: pointer;
-  border-radius: 14px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
-  overflow: hidden;
-  padding: 20px 18px;
+/* ─── Body ─── */
+
+const Body = styled.div`
+  padding: 14px 16px 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  /* Specific properties only — avoid transition:all which causes jitter */
-  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out, border-color 0.3s ease-in-out;
-  border: 1px solid ${({ theme }) => `${theme.primary}18`};
+  gap: 10px;
+  flex: 1;
+`;
+
+const TagRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+`;
+
+const Tag = styled.span`
+  font-size: 11px;
+  font-weight: 500;
+  color: ${({ theme }) => theme.primary};
+  background: ${({ theme }) => `${theme.primary}14`};
+  padding: 2px 10px;
+  border-radius: 50px;
+  border: 1px solid ${({ theme }) => `${theme.primary}28`};
+  white-space: nowrap;
+`;
+
+const Desc = styled.p`
+  font-size: 13px;
+  color: ${({ theme }) => theme.text_secondary};
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin: 0;
+  flex: 1;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 8px;
+  border-top: 1px solid ${({ theme }) => `${theme.text_primary}10`};
+`;
+
+const DateText = styled.span`
+  font-size: 11px;
+  color: ${({ theme }) => theme.text_secondary};
+`;
+
+const StatusPill = styled.span`
+  font-size: 11px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.primary};
+  background: ${({ theme }) => `${theme.primary}14`};
+  padding: 2px 10px;
+  border-radius: 50px;
+  border: 1px solid ${({ theme }) => `${theme.primary}28`};
+`;
+
+/* ─── Card wrapper ─── */
+
+const Card = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: ${({ theme }) => theme.card};
+  border-radius: 14px;
+  border: 1px solid ${({ theme }) => `${theme.text_primary}10`};
+  overflow: hidden;
+  cursor: pointer;
+  /* no min-height — card grows with content */
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 
   &:hover {
-    transform: translateY(-8px);
-    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.2);
-    border-color: ${({ theme }) => `${theme.primary}50`};
+    transform: translateY(-6px);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+    border-color: ${({ theme }) => `${theme.primary}40`};
   }
 
-  &:hover ${Image} {
-    transform: scale(1.05);
+  &:hover ${Img} {
+    transform: scale(1.06);
   }
 
-  &:hover ${HoverOverlay} {
+  &:hover ${ViewBadge} {
     opacity: 1;
   }
 `;
 
-const Tags = styled.div`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 2px;
-`;
+/* ─── Component ─── */
 
-const Tag = styled.span`
-  font-size: 12px;
-  font-weight: 500;
-  color: ${({ theme }) => theme.primary};
-  background-color: ${({ theme }) => `${theme.primary}18`};
-  padding: 3px 10px;
-  border-radius: 10px;
-  border: 1px solid ${({ theme }) => `${theme.primary}30`};
-`;
-
-const Details = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 0 2px;
-  flex: 1;
-`;
-
-const Title = styled.div`
-  font-size: 18px;
-  font-weight: 600;
-  color: ${({ theme }) => theme.text_primary};
-  overflow: hidden;
-  display: -webkit-box;
-  max-width: 100%;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  text-overflow: ellipsis;
-`;
-
-const Date = styled.div`
-  font-size: 12px;
-  font-weight: 400;
-  color: ${({ theme }) => theme.text_secondary};
-  margin-top: 2px;
-`;
-
-const Description = styled.div`
-  font-size: 14px;
-  font-weight: 400;
-  color: ${({ theme }) => theme.text_secondary};
-  overflow: hidden;
-  margin-top: 6px;
-  display: -webkit-box;
-  max-width: 100%;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  text-overflow: ellipsis;
-  line-height: 1.5;
-`;
-
-const Status = styled.span`
-  font-size: 12px;
-  font-weight: 500;
-  color: ${({ theme }) => theme.primary};
-  background-color: ${({ theme }) => `${theme.primary}18`};
-  padding: 3px 10px;
-  border-radius: 10px;
-  border: 1px solid ${({ theme }) => `${theme.primary}30`};
-  width: fit-content;
-`;
-
-const Members = styled.div`
-  display: flex;
-  align-items: center;
-  padding-left: 10px;
-`;
-
-const Avatar = styled.img`
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  margin-left: -10px;
-  background-color: ${({ theme }) => theme.white};
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
-  border: 3px solid ${({ theme }) => theme.card};
-`;
+const categoryLabel = (cat) => {
+  if (!cat) return null;
+  const c = Array.isArray(cat) ? cat[0] : cat;
+  const map = { "web app": "Web", "android app": "Android", "api": "API" };
+  return map[c] || c;
+};
 
 const ProjectCards = ({ project, setOpenModal }) => {
   const imageSrc = project?.imageUrl || project?.image || project?.img || "";
+  const label = categoryLabel(project?.category);
+
   return (
-    <Card onClick={() => setOpenModal({ state: true, project: project })}>
-      <ImageWrapper>
-        <Image src={imageSrc} alt={project?.title || "project image"} loading="lazy" />
-        <HoverOverlay>
-          <OverlayText>View Details →</OverlayText>
-        </HoverOverlay>
-      </ImageWrapper>
-      <Tags>
-        {project.tags?.map((tag, index) => (
-          <Tag key={index}>{tag}</Tag>
-        ))}
-      </Tags>
-      <Details>
-        <Title>{project.title}</Title>
-        <Date>{project.date}</Date>
-        {project.status && <Status>{project.status}</Status>}
-        <Description>{project.description}</Description>
-      </Details>
-      {project.member?.length > 0 && (
-        <Members>
-          {project.member.map((member, idx) => (
-            <Avatar key={idx} src={member.img} alt="" />
-          ))}
-        </Members>
-      )}
+    <Card onClick={() => setOpenModal({ state: true, project })}>
+      <ImageArea>
+        <Img src={imageSrc} alt={project?.title || "project"} loading="lazy" />
+        <ImageGradient />
+        {label && <CategoryBadge>{label}</CategoryBadge>}
+        <ImageTitle>{project?.title}</ImageTitle>
+        <ViewBadge>
+          <ViewLabel>View details</ViewLabel>
+        </ViewBadge>
+      </ImageArea>
+
+      <Body>
+        {project?.tags?.length > 0 && (
+          <TagRow>
+            {project.tags.slice(0, 4).map((tag, i) => (
+              <Tag key={i}>{tag}</Tag>
+            ))}
+          </TagRow>
+        )}
+
+        {project?.description && (
+          <Desc>{project.description}</Desc>
+        )}
+
+        <Footer>
+          <DateText>{project?.date}</DateText>
+          {project?.status && <StatusPill>{project.status}</StatusPill>}
+        </Footer>
+      </Body>
     </Card>
   );
 };

--- a/src/components/Cards/ProjectCards.jsx
+++ b/src/components/Cards/ProjectCards.jsx
@@ -1,48 +1,71 @@
 import React from "react";
 import styled from "styled-components";
 
-const Button = styled.button`
-  display: none;
+const ImageWrapper = styled.div`
+  position: relative;
   width: 100%;
-  padding: 10px;
-  background-color: ${({ theme }) => theme.white};
-  color: ${({ theme }) => theme.text_black};
-  font-size: 14px;
-  font-weight: 700;
-  border: none;
+  height: 180px;
   border-radius: 10px;
-  cursor: pointer;
-  transition: all 0.8s ease-in-out;
-`;
-const Card = styled.div`
-  width: 330px;
-  height: 490px;
-  background-color: ${({ theme }) => theme.card};
-  cursor: pointer;
-  border-radius: 10px;
-  box-shadow: 0 0 12px 4px rgba(0, 0, 0, 0.4);
   overflow: hidden;
-  padding: 26px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  transition: all 0.5s ease-in-out;
-  &:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 0 50px 4px rgba(0, 0, 0, 0.6);
-    filter: brightness(1.1);
-  }
-  &:hover ${Button} {
-    display: block;
-  }
+  box-shadow: 0 0 16px 2px rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
 `;
 
 const Image = styled.img`
   width: 100%;
-  height: 180px;
+  height: 100%;
+  object-fit: cover;
   background-color: ${({ theme }) => theme.white};
+  transition: transform 0.4s ease-in-out;
+`;
+
+const HoverOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
   border-radius: 10px;
-  box-shadow: 0 0 16px 2px rgba(0, 0, 0, 0.3);
+`;
+
+const OverlayText = styled.span`
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+`;
+
+const Card = styled.div`
+  width: 330px;
+  min-height: 420px;
+  background-color: ${({ theme }) => theme.card};
+  cursor: pointer;
+  border-radius: 14px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  padding: 20px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: all 0.35s ease-in-out;
+  border: 1px solid ${({ theme }) => `${theme.primary}18`};
+
+  &:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+    border-color: ${({ theme }) => `${theme.primary}50`};
+  }
+
+  &:hover ${Image} {
+    transform: scale(1.05);
+  }
+
+  &:hover ${HoverOverlay} {
+    opacity: 1;
+  }
 `;
 
 const Tags = styled.div`
@@ -50,59 +73,71 @@ const Tags = styled.div`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 4px;
+  gap: 6px;
+  margin-top: 2px;
 `;
 
 const Tag = styled.span`
   font-size: 12px;
-  font-weight: 400;
+  font-weight: 500;
   color: ${({ theme }) => theme.primary};
-  background-color: ${({ theme }) => theme.primary + 15};
-  padding: 2px 8px;
+  background-color: ${({ theme }) => `${theme.primary}18`};
+  padding: 3px 10px;
   border-radius: 10px;
+  border: 1px solid ${({ theme }) => `${theme.primary}30`};
 `;
 
 const Details = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 0px;
-  padding: 0px 2px;
+  gap: 4px;
+  padding: 0 2px;
+  flex: 1;
 `;
+
 const Title = styled.div`
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 600;
-  color: ${({ theme }) => theme.text_secondary};
+  color: ${({ theme }) => theme.text_primary};
   overflow: hidden;
   display: -webkit-box;
   max-width: 100%;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  overflow: hidden;
   text-overflow: ellipsis;
 `;
 
 const Date = styled.div`
   font-size: 12px;
-  margin-left: 2px;
   font-weight: 400;
-  color: ${({ theme }) => theme.text_secondary + 80};
-  @media only screen and (max-width: 768px) {
-    font-size: 10px;
-  }
+  color: ${({ theme }) => theme.text_secondary};
+  margin-top: 2px;
 `;
 
 const Description = styled.div`
+  font-size: 14px;
   font-weight: 400;
-  color: ${({ theme }) => theme.text_secondary + 99};
+  color: ${({ theme }) => theme.text_secondary};
   overflow: hidden;
-  margin-top: 8px;
+  margin-top: 6px;
   display: -webkit-box;
   max-width: 100%;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
+  line-height: 1.5;
+`;
+
+const Status = styled.span`
+  font-size: 12px;
+  font-weight: 500;
+  color: ${({ theme }) => theme.primary};
+  background-color: ${({ theme }) => `${theme.primary}18`};
+  padding: 3px 10px;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }) => `${theme.primary}30`};
+  width: fit-content;
 `;
 
 const Members = styled.div`
@@ -110,9 +145,10 @@ const Members = styled.div`
   align-items: center;
   padding-left: 10px;
 `;
+
 const Avatar = styled.img`
-  width: 38px;
-  height: 38px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   margin-left: -10px;
   background-color: ${({ theme }) => theme.white};
@@ -120,20 +156,16 @@ const Avatar = styled.img`
   border: 3px solid ${({ theme }) => theme.card};
 `;
 
-const Status = styled.span`
-  font-size: 14px;
-  font-weight: 400;
-  color: ${({ theme }) => theme.primary};
-  background-color: ${({ theme }) => theme.primary + 15};
-  padding: 2px 8px;
-  border-radius: 10px;
-`;
-
 const ProjectCards = ({ project, setOpenModal }) => {
   const imageSrc = project?.imageUrl || project?.image || project?.img || "";
   return (
     <Card onClick={() => setOpenModal({ state: true, project: project })}>
-      <Image src={imageSrc} alt={project?.title || "project image"} loading="lazy" />
+      <ImageWrapper>
+        <Image src={imageSrc} alt={project?.title || "project image"} loading="lazy" />
+        <HoverOverlay>
+          <OverlayText>View Details →</OverlayText>
+        </HoverOverlay>
+      </ImageWrapper>
       <Tags>
         {project.tags?.map((tag, index) => (
           <Tag key={index}>{tag}</Tag>
@@ -141,19 +173,17 @@ const ProjectCards = ({ project, setOpenModal }) => {
       </Tags>
       <Details>
         <Title>{project.title}</Title>
-
         <Date>{project.date}</Date>
-        <Tags>
-          <Status>{project.status}</Status>
-        </Tags>
+        {project.status && <Status>{project.status}</Status>}
         <Description>{project.description}</Description>
       </Details>
-      <Members>
-        {project.member?.map((member) => (
-          <Avatar src={member.img} />
-        ))}
-      </Members>
-      {/* <Button>View Project</Button> */}
+      {project.member?.length > 0 && (
+        <Members>
+          {project.member.map((member, idx) => (
+            <Avatar key={idx} src={member.img} alt="" />
+          ))}
+        </Members>
+      )}
     </Card>
   );
 };

--- a/src/components/Cards/ProjectCards.jsx
+++ b/src/components/Cards/ProjectCards.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import Tilt from "react-parallax-tilt";
 
 /* ─── Image area ─── */
 
@@ -191,6 +192,17 @@ const ProjectCards = ({ project, setOpenModal }) => {
   const label = categoryLabel(project?.category);
 
   return (
+    <Tilt
+      tiltMaxAngleX={7}
+      tiltMaxAngleY={7}
+      glareEnable={true}
+      glareMaxOpacity={0.1}
+      glareColor="rgba(255,255,255,0.4)"
+      glarePosition="all"
+      scale={1.02}
+      transitionSpeed={500}
+      style={{ borderRadius: '14px', height: '100%' }}
+    >
     <Card onClick={() => setOpenModal({ state: true, project })}>
       <ImageArea>
         <Img src={imageSrc} alt={project?.title || "project"} loading="lazy" />
@@ -221,6 +233,7 @@ const ProjectCards = ({ project, setOpenModal }) => {
         </Footer>
       </Body>
     </Card>
+    </Tilt>
   );
 };
 

--- a/src/components/Cards/ProjectCards.jsx
+++ b/src/components/Cards/ProjectCards.jsx
@@ -16,7 +16,7 @@ const Image = styled.img`
   height: 100%;
   object-fit: cover;
   background-color: ${({ theme }) => theme.white};
-  transition: transform 0.4s ease-in-out;
+  transition: transform 0.3s ease-in-out;
 `;
 
 const HoverOverlay = styled.div`
@@ -44,18 +44,19 @@ const Card = styled.div`
   background-color: ${({ theme }) => theme.card};
   cursor: pointer;
   border-radius: 14px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
   overflow: hidden;
   padding: 20px 18px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  transition: all 0.35s ease-in-out;
+  /* Specific properties only — avoid transition:all which causes jitter */
+  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out, border-color 0.3s ease-in-out;
   border: 1px solid ${({ theme }) => `${theme.primary}18`};
 
   &:hover {
     transform: translateY(-8px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.2);
     border-color: ${({ theme }) => `${theme.primary}50`};
   }
 

--- a/src/components/Certificates/index.js
+++ b/src/components/Certificates/index.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import useContent from '../../hooks/useContent';
 import { motion } from 'framer-motion';
 import { FaCertificate, FaExternalLinkAlt, FaFilter, FaTimes } from 'react-icons/fa';
+import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from '../SectionTitle';
 
 const CertificateDate = styled.div`
   font-size: 14px;
@@ -14,17 +15,6 @@ const CertificateDate = styled.div`
   }
 `;
 
-const fadeIn = keyframes`
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-`;
-
 const Container = styled.div`
     display: flex;
     flex-direction: column;
@@ -33,6 +23,7 @@ const Container = styled.div`
     z-index: 1;
     align-items: center;
     padding: 80px 0;
+    background: ${({ theme }) => theme.card_light};
 
     @media (max-width: 960px) {
         padding: 60px 0;
@@ -56,36 +47,6 @@ const Wrapper = styled.div`
     }
 `;
 
-const Title = styled.h2`
-    font-size: 42px;
-    font-weight: 700;
-    text-align: center;
-    margin-top: 20px;
-    color: ${({ theme }) => theme.text_primary};
-    animation: ${fadeIn} 0.5s ease-in-out;
-
-    @media (max-width: 768px) {
-        margin-top: 12px;
-        font-size: 36px;
-    }
-`;
-
-const Desc = styled.p`
-    font-size: 18px;
-    text-align: center;
-    max-width: 700px;
-    color: ${({ theme }) => theme.text_secondary};
-    line-height: 1.5;
-    margin-bottom: 40px;
-    animation: ${fadeIn} 0.5s ease-in-out 0.2s;
-    animation-fill-mode: both;
-
-    @media (max-width: 768px) {
-        font-size: 16px;
-        margin-bottom: 30px;
-        padding: 0 16px;
-    }
-`;
 
 const FilterContainer = styled.div`
     display: flex;
@@ -371,10 +332,21 @@ const Certificates = () => {
     return (
         <Container id="certificates">
             <Wrapper>
-                <Title>Certificates</Title>
-                <Desc>
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true, amount: 0.2 }}
+                    transition={{ duration: 0.5 }}
+                    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                >
+                <SectionHeadingWrapper>
+                    <SectionLabel>Achievements</SectionLabel>
+                    <SectionTitle>Certificates</SectionTitle>
+                </SectionHeadingWrapper>
+                <SectionDesc>
                     Professional certifications and achievements that showcase my expertise and continuous learning.
-                </Desc>
+                </SectionDesc>
+                </motion.div>
 
                 <FilterContainer>
                     <FaFilter size={16} style={{ color: '#777', marginRight: '8px' }} />

--- a/src/components/Certificates/index.js
+++ b/src/components/Certificates/index.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import useContent from '../../hooks/useContent';
-import { motion } from 'framer-motion';
-import { FaCertificate, FaExternalLinkAlt, FaFilter, FaTimes } from 'react-icons/fa';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FaCertificate, FaExternalLinkAlt } from 'react-icons/fa';
 import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from '../SectionTitle';
 
 const CertificateDate = styled.div`
@@ -48,71 +48,55 @@ const Wrapper = styled.div`
 `;
 
 
-const FilterContainer = styled.div`
+const FilterRow = styled.div`
     display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-    gap: 10px;
-    margin-bottom: 40px;
     flex-wrap: wrap;
-
-    @media (max-width: 768px) {
-        margin-bottom: 30px;
-    }
+    gap: 10px;
+    justify-content: center;
+    margin: 32px 0 40px;
 `;
 
-const FilterButton = styled.button`
-    display: flex;
+const FilterChip = styled.button`
+    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    gap: 8px;
-    padding: 10px 16px;
-    background: ${({ active, theme }) => active ? theme.primary : `${theme.card_light}`};
-    color: ${({ active, theme }) => active ? theme.white : theme.text_primary};
-    border: 1px solid ${({ active, theme }) => active ? theme.primary : `${theme.text_primary}30`};
-    border-radius: 10px;
-    font-weight: 500;
-    font-size: 14px;
-    cursor: pointer;
-    transition: all 0.3s ease;
-
-    &:hover {
-        background: ${({ active, theme }) => active ? theme.primary : `${theme.primary}20`};
-        transform: translateY(-3px);
-    }
-
-    @media (max-width: 768px) {
-        font-size: 12px;
-        padding: 8px 12px;
-    }
-`;
-
-const ClearFilterButton = styled.button`
-    display: flex;
-    align-items: center;
-    justify-content: center;
     gap: 6px;
-    padding: 10px 16px;
-    background: transparent;
-    color: ${({ theme }) => theme.text_secondary};
-    border: 1px solid ${({ theme }) => `${theme.text_secondary}50`};
-    border-radius: 10px;
-    font-weight: 500;
-    font-size: 14px;
+    padding: 8px 20px;
+    border-radius: 50px;
+    font-size: 13px;
+    font-weight: 600;
+    font-family: inherit;
+    letter-spacing: 0.4px;
     cursor: pointer;
-    transition: all 0.3s ease;
+    border: 1.5px solid ${({ active, theme }) => active ? theme.primary : `${theme.text_primary}25`};
+    background: ${({ active, theme }) => active ? theme.primary : 'transparent'};
+    color: ${({ active, theme }) => active ? '#fff' : theme.text_secondary};
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 
     &:hover {
-        color: ${({ theme }) => theme.text_primary};
-        border-color: ${({ theme }) => theme.text_primary};
-        transform: translateY(-3px);
+        border-color: ${({ theme }) => theme.primary};
+        color: ${({ active, theme }) => active ? '#fff' : theme.primary};
+        transform: translateY(-2px);
+        box-shadow: ${({ active }) => active
+            ? '0 6px 18px rgba(47,129,247,0.35)'
+            : '0 4px 12px rgba(47,129,247,0.12)'};
     }
 
-    @media (max-width: 768px) {
+    @media (max-width: 480px) {
+        padding: 7px 14px;
         font-size: 12px;
-        padding: 8px 12px;
     }
+`;
+
+const FilterCount = styled.span`
+    background: ${({ active, theme }) => active ? 'rgba(255,255,255,0.25)' : `${theme.primary}18`};
+    color: ${({ active, theme }) => active ? '#fff' : theme.primary};
+    border-radius: 50px;
+    padding: 0 7px;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.6;
+    min-width: 20px;
+    text-align: center;
 `;
 
 const CertificatesGrid = styled.div`
@@ -136,7 +120,7 @@ const CertificateCard = styled(motion.div)`
     border-radius: 16px;
     overflow: hidden;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
+    transition: transform 0.25s ease-in-out, box-shadow 0.25s ease-in-out, border-color 0.25s ease-in-out;
     position: relative;
     border: 1px solid ${({ theme }) => `${theme.primary}20`};
     height: 100%;
@@ -144,7 +128,7 @@ const CertificateCard = styled(motion.div)`
     &:hover {
         box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
         transform: translateY(-5px);
-        border: 1px solid ${({ theme }) => theme.primary};
+        border-color: ${({ theme }) => theme.primary};
     }
 `;
 
@@ -246,7 +230,7 @@ const ViewCertificateButton = styled.a`
     background: ${({ theme }) => theme.card_light};
     color: ${({ theme }) => theme.text_primary};
     padding: 10px 16px;
-    border-radius: 10px;
+    border-radius: 50px;
     font-weight: 500;
     font-size: 14px;
     display: flex;
@@ -255,7 +239,7 @@ const ViewCertificateButton = styled.a`
     gap: 8px;
     cursor: pointer;
     text-decoration: none;
-    transition: all 0.3s ease;
+    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
     margin-top: auto;
 
     &:hover {
@@ -295,39 +279,20 @@ const EmptyStateText = styled.p`
     }
 `;
 
-// Animation variants for cards
-const cardVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-        opacity: 1,
-        y: 0,
-        transition: {
-            duration: 0.4
-        }
-    }
-};
-
-const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-        opacity: 1,
-        transition: {
-            staggerChildren: 0.1
-        }
-    }
-};
+const humanLabel = (cat) => cat === 'all' ? 'All' : (cat ? cat.charAt(0).toUpperCase() + cat.slice(1) : cat);
 
 const Certificates = () => {
     const [activeFilter, setActiveFilter] = useState('all');
     const { data: certificates = [], loading } = useContent('certificates');
 
-    // Extract unique categories from certificates
-    const categories = ['all', ...new Set((certificates || []).map(cert => cert.category).filter(Boolean))];
+    const allCerts = certificates || [];
+    const categories = ['all', ...new Set(allCerts.map(cert => cert.category).filter(Boolean))];
 
-    // Filter certificates based on selected category
+    const countFor = (cat) => cat === 'all' ? allCerts.length : allCerts.filter(c => c.category === cat).length;
+
     const filteredCertificates = activeFilter === 'all'
-        ? certificates
-        : certificates.filter(cert => cert.category === activeFilter);
+        ? allCerts
+        : allCerts.filter(cert => cert.category === activeFilter);
 
     return (
         <Container id="certificates">
@@ -348,38 +313,30 @@ const Certificates = () => {
                 </SectionDesc>
                 </motion.div>
 
-                <FilterContainer>
-                    <FaFilter size={16} style={{ color: '#777', marginRight: '8px' }} />
-
-                    {categories.map((category, index) => (
-                        <FilterButton
-                            key={index}
+                <FilterRow>
+                    {categories.map((category) => (
+                        <FilterChip
+                            key={category}
                             active={activeFilter === category}
                             onClick={() => setActiveFilter(category)}
                         >
-                            {category.charAt(0).toUpperCase() + category.slice(1)}
-                        </FilterButton>
+                            {humanLabel(category)}
+                            <FilterCount active={activeFilter === category}>{countFor(category)}</FilterCount>
+                        </FilterChip>
                     ))}
-
-                    {activeFilter !== 'all' && (
-                        <ClearFilterButton onClick={() => setActiveFilter('all')}>
-                            <FaTimes size={12} />
-                            Clear Filter
-                        </ClearFilterButton>
-                    )}
-                </FilterContainer>
+                </FilterRow>
 
                 {!loading && filteredCertificates.length > 0 ? (
-                    <CertificatesGrid
-                        as={motion.div}
-                        variants={containerVariants}
-                        initial="hidden"
-                        animate="visible"
-                    >
+                    <CertificatesGrid>
+                        <AnimatePresence mode="popLayout">
                         {filteredCertificates.map((certificate, index) => (
                             <CertificateCard
-                                key={index}
-                                variants={cardVariants}
+                                key={`${activeFilter}-${certificate.title || index}`}
+                                layout
+                                initial={{ opacity: 0, scale: 0.96 }}
+                                animate={{ opacity: 1, scale: 1 }}
+                                exit={{ opacity: 0, scale: 0.94 }}
+                                transition={{ duration: 0.25, delay: index * 0.04 }}
                             >
                                 <CertificateCategory>
                                     {certificate.category.charAt(0).toUpperCase() + certificate.category.slice(1)}
@@ -417,6 +374,7 @@ const Certificates = () => {
                                 </CertificateDetails>
                             </CertificateCard>
                         ))}
+                        </AnimatePresence>
                     </CertificatesGrid>
                 ) : (
                     <EmptyStateContainer>

--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -42,25 +42,21 @@ const Wrapper = styled.div`
 
 
 const ContactForm = styled(motion.form)`
-  width: 100%;
-  max-width: 560px;
   flex: 1;
+  min-width: 0;
+  max-width: 560px;
   display: flex;
   flex-direction: column;
   background-color: ${({ theme }) => theme.card};
   padding: 32px;
   border-radius: 16px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
   gap: 20px;
-  transition: all 0.3s ease-in-out;
   border: 1px solid ${({ theme }) => `${theme.primary}15`};
 
-  &:hover {
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
-  }
-
   @media (max-width: 900px) {
-    width: 95%;
+    width: 100%;
+    max-width: 560px;
   }
 
   @media (max-width: 768px) {
@@ -198,30 +194,31 @@ const ContactButton = styled.button`
 
 const ContactBody = styled.div`
   display: flex;
-  gap: 48px;
-  align-items: flex-start;
+  gap: 40px;
+  align-items: stretch;
   justify-content: center;
   width: 100%;
-  max-width: 1000px;
+  max-width: 960px;
+  padding: 0 20px;
 
   @media (max-width: 900px) {
     flex-direction: column;
     align-items: center;
-    gap: 32px;
+    gap: 28px;
+    padding: 0;
   }
 `;
 
 const ContactInfo = styled(motion.div)`
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  min-width: 260px;
-  max-width: 300px;
+  gap: 14px;
+  width: 280px;
+  flex-shrink: 0;
 
   @media (max-width: 900px) {
-    max-width: 100%;
-    width: 95%;
-    min-width: unset;
+    width: 100%;
+    max-width: 560px;
   }
 `;
 

--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import emailjs from "@emailjs/browser";
 import { Snackbar, Alert, CircularProgress } from "@mui/material";
 import { motion } from "framer-motion";
@@ -90,7 +90,7 @@ const InputLabel = styled.label`
   font-size: ${({ isFocused, hasValue }) => (isFocused || hasValue ? '14px' : '16px')};
   color: ${({ theme, isFocused }) => (isFocused ? theme.primary : theme.text_secondary)};
   pointer-events: none;
-  transition: all 0.3s ease-in-out;
+  transition: top 0.3s ease-in-out, font-size 0.3s ease-in-out, color 0.3s ease-in-out, background-color 0.3s ease-in-out;
   background-color: ${({ theme, isFocused, hasValue }) =>
       (isFocused || hasValue) ? theme.card : 'transparent'};
   padding: 0 4px;
@@ -105,7 +105,7 @@ const InputIcon = styled.div`
   top: 14px;
   right: 16px;
   color: ${({ theme, isFocused }) => (isFocused ? theme.primary : theme.text_secondary)};
-  transition: all 0.3s ease-in-out;
+  transition: color 0.3s ease-in-out;
 `;
 
 const ContactInput = styled.input`
@@ -118,7 +118,7 @@ const ContactInput = styled.input`
   border-radius: 12px;
   padding: 12px 16px;
   padding-right: 40px;
-  transition: all 0.3s ease-in-out;
+  transition: border-color 0.3s ease-in-out;
   
   &:focus {
     border: 1px solid ${({ theme }) => theme.primary};
@@ -143,7 +143,7 @@ const ContactInputMessage = styled.textarea`
   padding-right: 40px;
   resize: vertical;
   min-height: 120px;
-  transition: all 0.3s ease-in-out;
+  transition: border-color 0.3s ease-in-out;
   
   &:focus {
     border: 1px solid ${({ theme }) => theme.primary};
@@ -174,7 +174,7 @@ const ContactButton = styled.button`
   align-items: center;
   justify-content: center;
   gap: 10px;
-  transition: all 0.3s ease-in-out;
+  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
 
   &:hover {
     transform: scale(1.02);
@@ -231,7 +231,7 @@ const InfoCard = styled.a`
   border-radius: 12px;
   border: 1px solid ${({ theme }) => `${theme.primary}20`};
   text-decoration: none;
-  transition: all 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out, border-color 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
   cursor: pointer;
 
   &:hover {
@@ -286,7 +286,7 @@ const formVariants = {
 };
 
 const Contact = () => {
-  // State for form inputs
+  const theme = useTheme();
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
   const [subject, setSubject] = useState("");
@@ -431,7 +431,7 @@ const Contact = () => {
               viewport={{ once: true }}
           >
             <ContactTitle>
-              <FiMail size={24} style={{ color: "#854CE6" }} />
+              <FiMail size={24} style={{ color: theme.primary }} />
               Let's Connect
             </ContactTitle>
 

--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -1,20 +1,12 @@
 import React, { useState, useRef } from "react";
-import styled, { keyframes } from "styled-components";
+import styled from "styled-components";
 import emailjs from "@emailjs/browser";
 import { Snackbar, Alert, CircularProgress } from "@mui/material";
 import { motion } from "framer-motion";
-import { FiMail, FiUser, FiFileText, FiSend } from "react-icons/fi";
-
-const fadeIn = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
+import { FiMail, FiUser, FiFileText, FiSend, FiMapPin } from "react-icons/fi";
+import { FaLinkedin, FaGithub } from "react-icons/fa";
+import { Bio } from "../../data/constants";
+import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from "../SectionTitle";
 
 const Container = styled.div`
   display: flex;
@@ -24,6 +16,7 @@ const Container = styled.div`
   z-index: 1;
   align-items: center;
   padding: 80px 0;
+  background: ${({ theme }) => theme.card_light};
 
   @media (max-width: 960px) {
     padding: 60px 0;
@@ -47,52 +40,27 @@ const Wrapper = styled.div`
   }
 `;
 
-const Title = styled.h2`
-  font-size: 42px;
-  font-weight: 700;
-  text-align: center;
-  margin-top: 20px;
-  margin-bottom: 8px;
-  color: ${({ theme }) => theme.text_primary};
-  animation: ${fadeIn} 0.5s ease-in-out;
-
-  @media (max-width: 768px) {
-    margin-top: 12px;
-    font-size: 36px;
-  }
-`;
-
-const Desc = styled.p`
-  font-size: 18px;
-  text-align: center;
-  max-width: 600px;
-  color: ${({ theme }) => theme.text_secondary};
-  line-height: 1.5;
-  margin-bottom: 40px;
-  animation: ${fadeIn} 0.5s ease-in-out 0.2s;
-  animation-fill-mode: both;
-
-  @media (max-width: 768px) {
-    font-size: 16px;
-    margin-bottom: 30px;
-  }
-`;
 
 const ContactForm = styled(motion.form)`
-  width: 95%;
-  max-width: 600px;
+  width: 100%;
+  max-width: 560px;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background-color: ${({ theme }) => theme.card};
   padding: 32px;
   border-radius: 16px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.08);
   gap: 20px;
   transition: all 0.3s ease-in-out;
+  border: 1px solid ${({ theme }) => `${theme.primary}15`};
 
   &:hover {
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
-    transform: translateY(-5px);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  }
+
+  @media (max-width: 900px) {
+    width: 95%;
   }
 
   @media (max-width: 768px) {
@@ -197,10 +165,7 @@ const ContactButton = styled.button`
   width: 100%;
   text-decoration: none;
   text-align: center;
-  background: ${({ theme }) => theme.primary};
-  background: linear-gradient(225deg, 
-    ${({ theme }) => theme.primary} 0%, 
-    ${({ theme }) => `${theme.primary}CC`} 100%);
+  background: linear-gradient(135deg, #2F81F7 0%, #0EA5E9 100%);
   padding: 16px;
   margin-top: 10px;
   border-radius: 12px;
@@ -214,21 +179,101 @@ const ContactButton = styled.button`
   justify-content: center;
   gap: 10px;
   transition: all 0.3s ease-in-out;
-  
+
   &:hover {
     transform: scale(1.02);
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 10px 25px rgba(47, 129, 247, 0.4);
   }
-  
+
   &:disabled {
     opacity: 0.7;
     cursor: not-allowed;
   }
-  
+
   @media (max-width: 768px) {
     padding: 12px;
     font-size: 14px;
   }
+`;
+
+const ContactBody = styled.div`
+  display: flex;
+  gap: 48px;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  max-width: 1000px;
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+  }
+`;
+
+const ContactInfo = styled(motion.div)`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 260px;
+  max-width: 300px;
+
+  @media (max-width: 900px) {
+    max-width: 100%;
+    width: 95%;
+    min-width: unset;
+  }
+`;
+
+const InfoCard = styled.a`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 20px;
+  background: ${({ theme }) => theme.card};
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => `${theme.primary}20`};
+  text-decoration: none;
+  transition: all 0.25s ease-in-out;
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-4px);
+    border-color: ${({ theme }) => `${theme.primary}60`};
+    box-shadow: 0 8px 20px rgba(47, 129, 247, 0.12);
+  }
+`;
+
+const InfoIcon = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: ${({ theme }) => `${theme.primary}18`};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.primary};
+  flex-shrink: 0;
+`;
+
+const InfoText = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const InfoLabel = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.text_secondary};
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+const InfoValue = styled.span`
+  font-size: 14px;
+  color: ${({ theme }) => theme.text_primary};
+  font-weight: 500;
 `;
 
 const formVariants = {
@@ -327,10 +372,58 @@ const Contact = () => {
   return (
       <Container id="contact">
         <Wrapper>
-          <Title>Contact</Title>
-          <Desc>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.2 }}
+            transition={{ duration: 0.5 }}
+            style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+          >
+          <SectionHeadingWrapper>
+            <SectionLabel>Get In Touch</SectionLabel>
+            <SectionTitle>Contact</SectionTitle>
+          </SectionHeadingWrapper>
+          <SectionDesc>
             Feel free to reach out to me for any questions or opportunities! I'll get back to you as soon as possible.
-          </Desc>
+          </SectionDesc>
+          </motion.div>
+
+          <ContactBody>
+            <ContactInfo
+              initial={{ opacity: 0, x: -20 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}
+            >
+              <InfoCard href={`mailto:jakub@example.com`} onClick={(e) => e.preventDefault()}>
+                <InfoIcon><FiMail size={20} /></InfoIcon>
+                <InfoText>
+                  <InfoLabel>Email</InfoLabel>
+                  <InfoValue>Send a message below</InfoValue>
+                </InfoText>
+              </InfoCard>
+              <InfoCard href={Bio.linkedin} target="_blank" rel="noopener noreferrer">
+                <InfoIcon><FaLinkedin size={20} /></InfoIcon>
+                <InfoText>
+                  <InfoLabel>LinkedIn</InfoLabel>
+                  <InfoValue>j-olszewski</InfoValue>
+                </InfoText>
+              </InfoCard>
+              <InfoCard href={Bio.github} target="_blank" rel="noopener noreferrer">
+                <InfoIcon><FaGithub size={20} /></InfoIcon>
+                <InfoText>
+                  <InfoLabel>GitHub</InfoLabel>
+                  <InfoValue>Olszewski-Jakub</InfoValue>
+                </InfoText>
+              </InfoCard>
+              <InfoCard as="div">
+                <InfoIcon><FiMapPin size={20} /></InfoIcon>
+                <InfoText>
+                  <InfoLabel>Location</InfoLabel>
+                  <InfoValue>Available for opportunities</InfoValue>
+                </InfoText>
+              </InfoCard>
+            </ContactInfo>
 
           <ContactForm
               ref={form}
@@ -432,6 +525,7 @@ const Contact = () => {
               )}
             </ContactButton>
           </ContactForm>
+          </ContactBody>
 
           <Snackbar
               open={open}

--- a/src/components/CursorSpotlight.js
+++ b/src/components/CursorSpotlight.js
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+
+const Overlay = styled.div`
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 9999;
+    transition: opacity 0.4s ease;
+`;
+
+const CursorSpotlight = ({ darkMode }) => {
+    const ref = useRef(null);
+
+    useEffect(() => {
+        if (!darkMode) return;
+
+        const el = ref.current;
+        if (!el) return;
+
+        const onMove = (e) => {
+            el.style.background = `radial-gradient(600px circle at ${e.clientX}px ${e.clientY}px, rgba(47,129,247,0.07), transparent 80%)`;
+        };
+
+        window.addEventListener('mousemove', onMove);
+        return () => window.removeEventListener('mousemove', onMove);
+    }, [darkMode]);
+
+    if (!darkMode) return null;
+
+    return <Overlay ref={ref} />;
+};
+
+export default CursorSpotlight;

--- a/src/components/Education/index.js
+++ b/src/components/Education/index.js
@@ -1,20 +1,10 @@
 import React, { useState } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import useContent from '../../hooks/useContent';
 import { motion } from 'framer-motion';
 import EducationCard from '../Cards/EducationCard';
 import { FaGraduationCap, FaAngleRight, FaSchool } from 'react-icons/fa';
-
-const fadeIn = keyframes`
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-`;
+import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from '../SectionTitle';
 
 const Container = styled.div`
     display: flex;
@@ -46,36 +36,6 @@ const Wrapper = styled.div`
     }
 `;
 
-const Title = styled.h2`
-    font-size: 42px;
-    font-weight: 700;
-    text-align: center;
-    margin-top: 20px;
-    color: ${({ theme }) => theme.text_primary};
-    animation: ${fadeIn} 0.5s ease-in-out;
-
-    @media (max-width: 768px) {
-        margin-top: 12px;
-        font-size: 36px;
-    }
-`;
-
-const Desc = styled.p`
-    font-size: 18px;
-    text-align: center;
-    max-width: 700px;
-    color: ${({ theme }) => theme.text_secondary};
-    line-height: 1.5;
-    margin-bottom: 40px;
-    animation: ${fadeIn} 0.5s ease-in-out 0.2s;
-    animation-fill-mode: both;
-
-    @media (max-width: 768px) {
-        font-size: 16px;
-        margin-bottom: 30px;
-        padding: 0 16px;
-    }
-`;
 
 const EducationContainer = styled.div`
     width: 100%;
@@ -199,11 +159,22 @@ const Education = () => {
     return (
         <Container id="education">
             <Wrapper>
-                <Title>Education</Title>
-                <Desc>
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true, amount: 0.2 }}
+                    transition={{ duration: 0.5 }}
+                    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                >
+                <SectionHeadingWrapper>
+                    <SectionLabel>Academic Background</SectionLabel>
+                    <SectionTitle>Education</SectionTitle>
+                </SectionHeadingWrapper>
+                <SectionDesc>
                     My academic journey has been a foundation for my career in technology.
                     Here are the educational experiences that have shaped my knowledge and skills.
-                </Desc>
+                </SectionDesc>
+                </motion.div>
 
                 <EducationContainer>
                     <TabsContainer numTabs={education.length}>

--- a/src/components/Education/index.js
+++ b/src/components/Education/index.js
@@ -87,7 +87,7 @@ const Tab = styled.div`
     color: ${({ active, theme }) => active ? theme.primary : theme.text_secondary};
     border-left: 3px solid ${({ active, theme }) => active ? theme.primary : 'transparent'};
     background-color: ${({ active, theme }) => active ? `${theme.primary}10` : 'transparent'};
-    transition: all 0.3s ease-in-out;
+    transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out, border-color 0.25s ease-in-out;
 
     &:hover {
         color: ${({ theme }) => theme.primary};

--- a/src/components/Education/index.js
+++ b/src/components/Education/index.js
@@ -14,6 +14,7 @@ const Container = styled.div`
     z-index: 1;
     align-items: center;
     padding: 80px 0;
+    background: ${({ theme }) => theme.bg};
 
     @media (max-width: 960px) {
         padding: 60px 0;

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -59,7 +59,7 @@ const HeaderArea = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 36px 20px 20px;
+    padding: 14px 20px 6px;
     flex-shrink: 0;
 `;
 
@@ -457,9 +457,9 @@ const Experience = () => {
                     </ProgressTrack>
 
                     <HeaderArea>
-                        <SectionHeadingWrapper style={{ marginBottom: 0 }}>
-                            <SectionLabel>My Journey</SectionLabel>
-                            <SectionTitle>Experience</SectionTitle>
+                        <SectionHeadingWrapper style={{ marginBottom: 0, gap: 0 }}>
+                            <SectionLabel style={{ marginBottom: 8 }}>My Journey</SectionLabel>
+                            <SectionTitle style={{ marginTop: 0, fontSize: '32px' }}>Experience</SectionTitle>
                         </SectionHeadingWrapper>
                     </HeaderArea>
 

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -1,20 +1,10 @@
 import React, {useEffect, useState} from 'react';
-import styled, {keyframes} from 'styled-components';
+import styled from 'styled-components';
 import ExperienceCard from '../Cards/ExperienceCard';
 import useContent from '../../hooks/useContent';
 import {motion} from 'framer-motion';
 import {FaAngleRight, FaBriefcase} from 'react-icons/fa';
-
-const fadeIn = keyframes`
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-`;
+import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from '../SectionTitle';
 
 const Container = styled.div`
     display: flex;
@@ -24,6 +14,7 @@ const Container = styled.div`
     z-index: 1;
     align-items: center;
     padding: 80px 0;
+    background: ${({ theme }) => theme.card_light};
 
     @media (max-width: 960px) {
         padding: 60px 0;
@@ -46,36 +37,6 @@ const Wrapper = styled.div`
     }
 `;
 
-const Title = styled.h2`
-    font-size: 42px;
-    font-weight: 700;
-    text-align: center;
-    margin-top: 20px;
-  color: ${({ theme }) => theme.text_primary};
-    animation: ${fadeIn} 0.5s ease-in-out;
-
-    @media (max-width: 768px) {
-        margin-top: 12px;
-        font-size: 36px;
-  }
-`;
-
-const Desc = styled.p`
-    font-size: 18px;
-    text-align: center;
-    max-width: 700px;
-    color: ${({theme}) => theme.text_secondary};
-    line-height: 1.5;
-    margin-bottom: 40px;
-    animation: ${fadeIn} 0.5s ease-in-out 0.2s;
-    animation-fill-mode: both;
-
-    @media (max-width: 768px) {
-        font-size: 16px;
-        margin-bottom: 30px;
-        padding: 0 16px;
-    }
-`;
 
 const ExperienceContainer = styled.div`
     width: 100%;
@@ -227,13 +188,23 @@ const Experience = () => {
     return (
         <Container id="experience">
             <Wrapper>
-                <Title>Experience</Title>
-                <Desc>
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true, amount: 0.2 }}
+                    transition={{ duration: 0.5 }}
+                    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                >
+                <SectionHeadingWrapper>
+                    <SectionLabel>My Journey</SectionLabel>
+                    <SectionTitle>Experience</SectionTitle>
+                </SectionHeadingWrapper>
+                <SectionDesc>
                     My professional journey as a software engineer, working with different companies and on various
-                    projects.
-                    These experiences have helped me grow and develop my skills in different technologies and
+                    projects. These experiences have helped me grow and develop my skills in different technologies and
                     environments.
-                </Desc>
+                </SectionDesc>
+                </motion.div>
 
                 <ExperienceContainer>
                     <TabsContainer numTabs={experiences.length}>

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -1,333 +1,52 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { motion, useScroll, useTransform, useMotionValueEvent } from 'framer-motion';
 import ExperienceCard from '../Cards/ExperienceCard';
 import useContent from '../../hooks/useContent';
-import { SectionLabel, SectionTitle, SectionHeadingWrapper } from '../SectionTitle';
-import { FaCalendarAlt, FaMapMarkerAlt, FaExternalLinkAlt } from 'react-icons/fa';
+import { motion } from 'framer-motion';
+import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from '../SectionTitle';
 
-/* ── Mobile detection ── */
-const useIsMobile = () => {
-    const [isMobile, setIsMobile] = useState(false);
-    useEffect(() => {
-        const mq = window.matchMedia('(max-width: 860px)');
-        setIsMobile(mq.matches);
-        const handler = e => setIsMobile(e.matches);
-        mq.addEventListener('change', handler);
-        return () => mq.removeEventListener('change', handler);
-    }, []);
-    return isMobile;
-};
-
-/* ── Shared wrapper ── */
-const Outer = styled.div`
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+    z-index: 1;
+    align-items: center;
+    padding: 80px 0;
     background: ${({ theme }) => theme.card_light};
+
+    @media (max-width: 960px) {
+        padding: 60px 0;
+    }
+`;
+
+const Wrapper = styled.div`
     position: relative;
-`;
-
-/* ── Desktop horizontal scroll ── */
-
-const ScrollSpace = styled.div`
-    height: ${({ $count }) => $count * 100}vh;
-    position: relative;
-`;
-
-const NAVBAR_H = 80;
-
-const StickyWrap = styled.div`
-    position: sticky;
-    top: ${NAVBAR_H}px;
-    height: calc(100vh - ${NAVBAR_H}px);
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-`;
-
-const ProgressTrack = styled.div`
-    height: 3px;
-    background: ${({ theme }) => `${theme.primary}18`};
-    flex-shrink: 0;
-`;
-
-const ProgressFill = styled(motion.div)`
-    height: 100%;
-    background: linear-gradient(90deg, #2F81F7, #0EA5E9);
-    transform-origin: left;
-`;
-
-const HeaderArea = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 14px 20px 6px;
-    flex-shrink: 0;
-`;
-
-const Track = styled(motion.div)`
-    display: flex;
-    flex: 1;
-    min-height: 0;
-    width: ${({ $count }) => $count * 100}vw;
-    will-change: transform;
-`;
-
-const Panel = styled.div`
-    flex: 0 0 100vw;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0 40px;
-    box-sizing: border-box;
-`;
-
-const PanelInner = styled.div`
-    max-width: 1100px;
     width: 100%;
-    display: grid;
-    grid-template-columns: 340px 1fr;
-    gap: 64px;
-    align-items: start;
-    max-height: calc(100vh - 180px);
-`;
-
-const Left = styled.div`
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    padding-top: 8px;
-`;
-
-const IndexWatermark = styled.div`
-    position: absolute;
-    top: -24px;
-    left: -16px;
-    font-size: 120px;
-    font-weight: 900;
-    line-height: 1;
-    color: ${({ theme }) => theme.primary};
-    opacity: 0.06;
-    pointer-events: none;
-    user-select: none;
-    letter-spacing: -6px;
-`;
-
-const LogoBox = styled.div`
-    width: 72px;
-    height: 72px;
-    border-radius: 16px;
-    background: ${({ theme }) => theme.white};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 4px 16px rgba(0,0,0,0.1);
-    overflow: hidden;
-    flex-shrink: 0;
-    margin-bottom: 4px;
-`;
-
-const Logo = styled.img`
-    width: 76%;
-    height: 76%;
-    object-fit: contain;
-`;
-
-const Role = styled.h2`
-    font-size: 26px;
-    font-weight: 700;
-    color: ${({ theme }) => theme.text_primary};
-    line-height: 1.3;
-`;
-
-const CompanyName = styled.div`
-    font-size: 16px;
-    font-weight: 500;
-`;
-
-const CompanyLink = styled.a`
-    color: ${({ theme }) => theme.primary};
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    transition: opacity 0.2s ease;
-
-    &:hover { opacity: 0.75; }
-`;
-
-const MetaRow = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 4px;
-`;
-
-const MetaItem = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 13px;
-    color: ${({ theme }) => theme.text_secondary};
-`;
-
-const Right = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-    overflow-y: auto;
-    max-height: calc(100vh - 200px);
-    padding-right: 4px;
-
-    &::-webkit-scrollbar { width: 4px; }
-    &::-webkit-scrollbar-track { background: transparent; }
-    &::-webkit-scrollbar-thumb {
-        background: ${({ theme }) => `${theme.primary}30`};
-        border-radius: 4px;
-    }
-`;
-
-const Description = styled.div`
-    font-size: 15px;
-    line-height: 1.7;
-    color: ${({ theme }) => theme.text_primary + 'dd'};
-`;
-
-const SkillsWrap = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-`;
-
-const SkillsLabel = styled.div`
-    font-size: 12px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1.2px;
-    color: ${({ theme }) => theme.text_secondary};
-`;
-
-const SkillList = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-`;
-
-const SkillPill = styled.div`
-    font-size: 13px;
-    font-weight: 500;
-    padding: 5px 13px;
-    border-radius: 20px;
-    color: ${({ theme }) => theme.primary};
-    background: ${({ theme }) => `${theme.primary}18`};
-    transition: background-color 0.2s ease, transform 0.2s ease;
-
-    &:hover {
-        background: ${({ theme }) => `${theme.primary}30`};
-        transform: translateY(-1px);
-    }
-`;
-
-const LinksRow = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-`;
-
-const LinkBtn = styled.a`
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 13px;
-    font-weight: 500;
-    padding: 7px 14px;
-    border-radius: 8px;
-    color: ${({ theme }) => theme.primary};
-    background: ${({ theme }) => `${theme.primary}15`};
-    text-decoration: none;
-    transition: background-color 0.2s ease, transform 0.2s ease;
-
-    &:hover {
-        background: ${({ theme }) => `${theme.primary}28`};
-        transform: translateY(-2px);
-    }
-`;
-
-const NavBar = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px 40px 20px;
-    flex-shrink: 0;
-`;
-
-const Dots = styled.div`
-    display: flex;
-    gap: 8px;
-    align-items: center;
-`;
-
-const NavDot = styled.div`
-    width: ${({ $active }) => ($active ? '24px' : '8px')};
-    height: 8px;
-    border-radius: 4px;
-    background: ${({ theme, $active }) => $active ? theme.primary : `${theme.primary}30`};
-    transition: width 0.3s ease, background-color 0.3s ease;
-`;
-
-const SlideCount = styled.div`
-    font-size: 13px;
-    font-weight: 600;
-    color: ${({ theme }) => theme.text_secondary};
-    letter-spacing: 0.5px;
-`;
-
-const ScrollHint = styled(motion.div)`
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 12px;
-    font-weight: 500;
-    color: ${({ theme }) => theme.text_secondary};
-    opacity: 0.7;
-`;
-
-const HintLine = styled.div`
-    width: 32px;
-    height: 2px;
-    background: ${({ theme }) => `${theme.primary}50`};
-    border-radius: 1px;
-`;
-
-/* ── Mobile fallback ── */
-const MobileContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 60px 16px 60px;
+    max-width: 1100px;
+    padding: 0 20px;
     gap: 0;
 `;
 
-const MobileWrapper = styled.div`
-    width: 100%;
-    max-width: 680px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-`;
+/* ── Timeline ── */
 
-const MobileTimeline = styled.div`
+const Timeline = styled.div`
     position: relative;
     width: 100%;
-    padding: 40px 0 0 40px;
+    padding: 48px 0 0;
 
+    /* Vertical centre line */
     &::before {
         content: '';
         position: absolute;
-        left: 16px;
+        left: 50%;
         top: 0;
         bottom: 0;
         width: 2px;
+        transform: translateX(-50%);
         background: linear-gradient(
             to bottom,
             transparent,
@@ -336,233 +55,119 @@ const MobileTimeline = styled.div`
             transparent
         );
     }
+
+    @media (max-width: 768px) {
+        padding-left: 40px;
+        &::before {
+            left: 16px;
+            transform: none;
+        }
+    }
 `;
 
-const MobileEntry = styled.div`
+const TimelineEntry = styled.div`
+    display: flex;
+    justify-content: ${({ $isLeft }) => ($isLeft ? 'flex-end' : 'flex-start')};
+    padding-bottom: 60px;
     position: relative;
-    padding-bottom: 40px;
+
+    @media (max-width: 768px) {
+        justify-content: flex-start;
+        padding-bottom: 40px;
+    }
 `;
 
-const MobileDot = styled.div`
+const EntryCard = styled(motion.div)`
+    width: calc(50% - 52px);
+
+    @media (max-width: 768px) {
+        width: 100%;
+    }
+`;
+
+/* Glowing dot on the timeline */
+const Dot = styled.div`
     position: absolute;
-    left: -32px;
+    left: 50%;
     top: 30px;
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     background: ${({ theme }) => theme.primary};
     border: 3px solid ${({ theme }) => theme.card_light};
     box-shadow:
-        0 0 0 3px ${({ theme }) => `${theme.primary}35`},
-        0 0 16px ${({ theme }) => `${theme.primary}50`};
+        0 0 0 4px ${({ theme }) => `${theme.primary}35`},
+        0 0 20px ${({ theme }) => `${theme.primary}50`};
+    transform: translateX(-50%);
     z-index: 2;
+
+    @media (max-width: 768px) {
+        left: 16px;
+    }
 `;
 
-/* ── Component ── */
+/* Horizontal connector line from dot to card */
+const Connector = styled.div`
+    position: absolute;
+    top: 37px;
+    height: 2px;
+    width: 36px;
+    background: ${({ theme }) => `${theme.primary}50`};
+    ${({ $isLeft }) => $isLeft ? 'right: calc(50% + 16px);' : 'left: calc(50% + 16px);'}
+
+    @media (max-width: 768px) {
+        display: none;
+    }
+`;
 
 const Experience = () => {
     const { data: experiences = [], loading } = useContent('experience');
-    const isMobile = useIsMobile();
-    const containerRef = useRef(null);
-    const [activeIndex, setActiveIndex] = useState(0);
-    const [vw, setVw] = useState(() =>
-        typeof window !== 'undefined' ? window.innerWidth : 1200
-    );
 
-    useEffect(() => {
-        const onResize = () => setVw(window.innerWidth);
-        window.addEventListener('resize', onResize);
-        return () => window.removeEventListener('resize', onResize);
-    }, []);
-
-    const { scrollY } = useScroll();
-    const [scrollRange, setScrollRange] = useState([0, 1]);
-
-    const count = experiences.length || 1;
-
-    useEffect(() => {
-        const el = containerRef.current;
-        if (!el || !experiences.length) return;
-        const measure = () => {
-            requestAnimationFrame(() => {
-                const rect = el.getBoundingClientRect();
-                const top = window.scrollY + rect.top;
-                setScrollRange([top, top + el.offsetHeight - window.innerHeight]);
-            });
-        };
-        measure();
-        window.addEventListener('resize', measure);
-        return () => window.removeEventListener('resize', measure);
-    }, [experiences.length]);
-
-    const scrollYProgress = useTransform(scrollY, scrollRange, [0, 1], { clamp: true });
-    const x = useTransform(scrollYProgress, [0, 1], [0, -(count - 1) * vw]);
-
-    useMotionValueEvent(scrollYProgress, 'change', v => {
-        const idx = Math.floor(v * count);
-        setActiveIndex(Math.min(count - 1, Math.max(0, idx)));
-    });
-
-    if (loading) return null;
-
-    /* Mobile layout */
-    if (isMobile) {
-        return (
-            <Outer id="experience">
-                <MobileContainer>
-                    <MobileWrapper>
-                        <motion.div
-                            initial={{ opacity: 0, y: 20 }}
-                            whileInView={{ opacity: 1, y: 0 }}
-                            viewport={{ once: true, amount: 0.2 }}
-                            transition={{ duration: 0.5 }}
-                            style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', marginBottom: '32px' }}
-                        >
-                            <SectionHeadingWrapper>
-                                <SectionLabel>My Journey</SectionLabel>
-                                <SectionTitle>Experience</SectionTitle>
-                            </SectionHeadingWrapper>
-                        </motion.div>
-
-                        {experiences.length > 0 && (
-                            <MobileTimeline>
-                                {experiences.map((exp, i) => (
-                                    <MobileEntry key={i}>
-                                        <MobileDot />
-                                        <motion.div
-                                            initial={{ opacity: 0, x: -30 }}
-                                            whileInView={{ opacity: 1, x: 0 }}
-                                            viewport={{ once: true, amount: 0.1 }}
-                                            transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
-                                        >
-                                            <ExperienceCard experience={exp} />
-                                        </motion.div>
-                                    </MobileEntry>
-                                ))}
-                            </MobileTimeline>
-                        )}
-                    </MobileWrapper>
-                </MobileContainer>
-            </Outer>
-        );
-    }
-
-    /* Desktop horizontal scroll */
     return (
-        <Outer id="experience">
-            <ScrollSpace ref={containerRef} $count={count}>
-                <StickyWrap>
-                    <ProgressTrack>
-                        <ProgressFill style={{ scaleX: scrollYProgress }} />
-                    </ProgressTrack>
+        <Container id="experience">
+            <Wrapper>
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true, amount: 0.2 }}
+                    transition={{ duration: 0.5 }}
+                    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
+                >
+                    <SectionHeadingWrapper>
+                        <SectionLabel>My Journey</SectionLabel>
+                        <SectionTitle>Experience</SectionTitle>
+                    </SectionHeadingWrapper>
+                    <SectionDesc>
+                        The roles and projects that have shaped my skills and perspective as a developer.
+                    </SectionDesc>
+                </motion.div>
 
-                    <HeaderArea>
-                        <SectionHeadingWrapper style={{ marginBottom: 0, gap: 0 }}>
-                            <SectionLabel style={{ marginBottom: 8 }}>My Journey</SectionLabel>
-                            <SectionTitle style={{ marginTop: 0, fontSize: '32px' }}>Experience</SectionTitle>
-                        </SectionHeadingWrapper>
-                    </HeaderArea>
-
-                    <Track style={{ x }} $count={count}>
-                        {experiences.map((exp, i) => (
-                            <Panel key={i}>
-                                <PanelInner>
-                                    <Left>
-                                        <IndexWatermark>
-                                            {String(i + 1).padStart(2, '0')}
-                                        </IndexWatermark>
-                                        <LogoBox>
-                                            <Logo src={exp.img} alt={exp.company} />
-                                        </LogoBox>
-                                        <Role>{exp.role}</Role>
-                                        <CompanyName>
-                                            {exp.companyUrl ? (
-                                                <CompanyLink href={exp.companyUrl} target="_blank" rel="noopener noreferrer">
-                                                    {exp.company}
-                                                    <FaExternalLinkAlt size={11} />
-                                                </CompanyLink>
-                                            ) : exp.company}
-                                        </CompanyName>
-                                        <MetaRow>
-                                            <MetaItem>
-                                                <FaCalendarAlt size={12} />
-                                                {exp.date}
-                                            </MetaItem>
-                                            {exp.location && (
-                                                <MetaItem>
-                                                    <FaMapMarkerAlt size={12} />
-                                                    {exp.location}
-                                                </MetaItem>
-                                            )}
-                                        </MetaRow>
-                                    </Left>
-
-                                    <Right>
-                                        {exp.desc && (
-                                            <Description
-                                                dangerouslySetInnerHTML={{
-                                                    __html: exp.desc.replace(/\n/g, '<br />')
-                                                }}
-                                            />
-                                        )}
-
-                                        {exp.skills?.length > 0 && (
-                                            <SkillsWrap>
-                                                <SkillsLabel>Technologies</SkillsLabel>
-                                                <SkillList>
-                                                    {exp.skills.map((s, j) => (
-                                                        <SkillPill key={j}>{s}</SkillPill>
-                                                    ))}
-                                                </SkillList>
-                                            </SkillsWrap>
-                                        )}
-
-                                        {(exp.doc || exp.pdf || exp.additionalResources?.length > 0) && (
-                                            <LinksRow>
-                                                {exp.doc && (
-                                                    <LinkBtn href={exp.doc} target="_blank" rel="noopener noreferrer">
-                                                        <FaExternalLinkAlt size={11} /> View Certificate
-                                                    </LinkBtn>
-                                                )}
-                                                {exp.pdf && (
-                                                    <LinkBtn href={exp.pdf} target="_blank" rel="noopener noreferrer">
-                                                        <FaExternalLinkAlt size={11} /> View PDF
-                                                    </LinkBtn>
-                                                )}
-                                                {exp.additionalResources?.map((r, j) => (
-                                                    <LinkBtn key={j} href={r.url} target="_blank" rel="noopener noreferrer">
-                                                        {r.icon} {r.title}
-                                                    </LinkBtn>
-                                                ))}
-                                            </LinksRow>
-                                        )}
-                                    </Right>
-                                </PanelInner>
-                            </Panel>
-                        ))}
-                    </Track>
-
-                    <NavBar>
-                        <Dots>
-                            {experiences.map((_, i) => (
-                                <NavDot key={i} $active={i === activeIndex} />
-                            ))}
-                        </Dots>
-                        <ScrollHint
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: activeIndex === count - 1 ? 0 : 1 }}
-                            transition={{ duration: 0.4 }}
-                        >
-                            Scroll to continue
-                            <HintLine />
-                        </ScrollHint>
-                        <SlideCount>
-                            {String(activeIndex + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
-                        </SlideCount>
-                    </NavBar>
-                </StickyWrap>
-            </ScrollSpace>
-        </Outer>
+                {!loading && experiences.length > 0 && (
+                    <Timeline>
+                        {experiences.map((exp, index) => {
+                            const isLeft = index % 2 === 0;
+                            return (
+                                <TimelineEntry key={index} $isLeft={isLeft}>
+                                    <Dot />
+                                    <Connector $isLeft={isLeft} />
+                                    <EntryCard
+                                        initial={{ opacity: 0, x: isLeft ? -50 : 50 }}
+                                        whileInView={{ opacity: 1, x: 0 }}
+                                        viewport={{ once: true, amount: 0.15 }}
+                                        transition={{
+                                            duration: 0.55,
+                                            ease: [0.16, 1, 0.3, 1],
+                                        }}
+                                    >
+                                        <ExperienceCard experience={exp} />
+                                    </EntryCard>
+                                </TimelineEntry>
+                            );
+                        })}
+                    </Timeline>
+                )}
+            </Wrapper>
+        </Container>
     );
 };
 

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -1,52 +1,331 @@
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { motion, useScroll, useTransform, useMotionValueEvent } from 'framer-motion';
 import ExperienceCard from '../Cards/ExperienceCard';
 import useContent from '../../hooks/useContent';
-import { motion } from 'framer-motion';
-import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from '../SectionTitle';
+import { SectionLabel, SectionTitle, SectionHeadingWrapper } from '../SectionTitle';
+import { FaCalendarAlt, FaMapMarkerAlt, FaExternalLinkAlt } from 'react-icons/fa';
 
-const Container = styled.div`
+/* ── Mobile detection ── */
+const useIsMobile = () => {
+    const [isMobile, setIsMobile] = useState(false);
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 860px)');
+        setIsMobile(mq.matches);
+        const handler = e => setIsMobile(e.matches);
+        mq.addEventListener('change', handler);
+        return () => mq.removeEventListener('change', handler);
+    }, []);
+    return isMobile;
+};
+
+/* ── Shared wrapper ── */
+const Outer = styled.div`
+    background: ${({ theme }) => theme.card_light};
+    position: relative;
+`;
+
+/* ── Desktop horizontal scroll ── */
+
+const ScrollSpace = styled.div`
+    height: ${({ $count }) => $count * 100}vh;
+    position: relative;
+`;
+
+const StickyWrap = styled.div`
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    position: relative;
-    z-index: 1;
-    align-items: center;
-    padding: 80px 0;
-    background: ${({ theme }) => theme.card_light};
+`;
 
-    @media (max-width: 960px) {
-        padding: 60px 0;
+const ProgressTrack = styled.div`
+    height: 3px;
+    background: ${({ theme }) => `${theme.primary}18`};
+    flex-shrink: 0;
+`;
+
+const ProgressFill = styled(motion.div)`
+    height: 100%;
+    background: linear-gradient(90deg, #2F81F7, #0EA5E9);
+    transform-origin: left;
+`;
+
+const HeaderArea = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 36px 20px 20px;
+    flex-shrink: 0;
+`;
+
+const Track = styled(motion.div)`
+    display: flex;
+    flex: 1;
+    will-change: transform;
+    min-height: 0;
+`;
+
+const Panel = styled.div`
+    min-width: 100vw;
+    width: 100vw;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 40px;
+    box-sizing: border-box;
+`;
+
+const PanelInner = styled.div`
+    max-width: 1100px;
+    width: 100%;
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    gap: 64px;
+    align-items: start;
+    max-height: calc(100vh - 180px);
+`;
+
+const Left = styled.div`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 8px;
+`;
+
+const IndexWatermark = styled.div`
+    position: absolute;
+    top: -24px;
+    left: -16px;
+    font-size: 120px;
+    font-weight: 900;
+    line-height: 1;
+    color: ${({ theme }) => theme.primary};
+    opacity: 0.06;
+    pointer-events: none;
+    user-select: none;
+    letter-spacing: -6px;
+`;
+
+const LogoBox = styled.div`
+    width: 72px;
+    height: 72px;
+    border-radius: 16px;
+    background: ${({ theme }) => theme.white};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+    overflow: hidden;
+    flex-shrink: 0;
+    margin-bottom: 4px;
+`;
+
+const Logo = styled.img`
+    width: 76%;
+    height: 76%;
+    object-fit: contain;
+`;
+
+const Role = styled.h2`
+    font-size: 26px;
+    font-weight: 700;
+    color: ${({ theme }) => theme.text_primary};
+    line-height: 1.3;
+`;
+
+const CompanyName = styled.div`
+    font-size: 16px;
+    font-weight: 500;
+`;
+
+const CompanyLink = styled.a`
+    color: ${({ theme }) => theme.primary};
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    transition: opacity 0.2s ease;
+
+    &:hover { opacity: 0.75; }
+`;
+
+const MetaRow = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+`;
+
+const MetaItem = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: ${({ theme }) => theme.text_secondary};
+`;
+
+const Right = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    overflow-y: auto;
+    max-height: calc(100vh - 200px);
+    padding-right: 4px;
+
+    &::-webkit-scrollbar { width: 4px; }
+    &::-webkit-scrollbar-track { background: transparent; }
+    &::-webkit-scrollbar-thumb {
+        background: ${({ theme }) => `${theme.primary}30`};
+        border-radius: 4px;
     }
 `;
 
-const Wrapper = styled.div`
-    position: relative;
+const Description = styled.div`
+    font-size: 15px;
+    line-height: 1.7;
+    color: ${({ theme }) => theme.text_primary + 'dd'};
+`;
+
+const SkillsWrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+`;
+
+const SkillsLabel = styled.div`
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: ${({ theme }) => theme.text_secondary};
+`;
+
+const SkillList = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+`;
+
+const SkillPill = styled.div`
+    font-size: 13px;
+    font-weight: 500;
+    padding: 5px 13px;
+    border-radius: 20px;
+    color: ${({ theme }) => theme.primary};
+    background: ${({ theme }) => `${theme.primary}18`};
+    transition: background-color 0.2s ease, transform 0.2s ease;
+
+    &:hover {
+        background: ${({ theme }) => `${theme.primary}30`};
+        transform: translateY(-1px);
+    }
+`;
+
+const LinksRow = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+`;
+
+const LinkBtn = styled.a`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 7px 14px;
+    border-radius: 8px;
+    color: ${({ theme }) => theme.primary};
+    background: ${({ theme }) => `${theme.primary}15`};
+    text-decoration: none;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+
+    &:hover {
+        background: ${({ theme }) => `${theme.primary}28`};
+        transform: translateY(-2px);
+    }
+`;
+
+const NavBar = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 40px 20px;
+    flex-shrink: 0;
+`;
+
+const Dots = styled.div`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+`;
+
+const NavDot = styled.div`
+    width: ${({ $active }) => ($active ? '24px' : '8px')};
+    height: 8px;
+    border-radius: 4px;
+    background: ${({ theme, $active }) => $active ? theme.primary : `${theme.primary}30`};
+    transition: width 0.3s ease, background-color 0.3s ease;
+`;
+
+const SlideCount = styled.div`
+    font-size: 13px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.text_secondary};
+    letter-spacing: 0.5px;
+`;
+
+const ScrollHint = styled(motion.div)`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    font-weight: 500;
+    color: ${({ theme }) => theme.text_secondary};
+    opacity: 0.7;
+`;
+
+const HintLine = styled.div`
+    width: 32px;
+    height: 2px;
+    background: ${({ theme }) => `${theme.primary}50`};
+    border-radius: 1px;
+`;
+
+/* ── Mobile fallback ── */
+const MobileContainer = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 100%;
-    max-width: 1100px;
-    padding: 0 20px;
+    padding: 60px 16px 60px;
     gap: 0;
 `;
 
-/* ── Timeline ── */
+const MobileWrapper = styled.div`
+    width: 100%;
+    max-width: 680px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
 
-const Timeline = styled.div`
+const MobileTimeline = styled.div`
     position: relative;
     width: 100%;
-    padding: 48px 0 0;
+    padding: 40px 0 0 40px;
 
-    /* Vertical centre line */
     &::before {
         content: '';
         position: absolute;
-        left: 50%;
+        left: 16px;
         top: 0;
         bottom: 0;
         width: 2px;
-        transform: translateX(-50%);
         background: linear-gradient(
             to bottom,
             transparent,
@@ -55,119 +334,209 @@ const Timeline = styled.div`
             transparent
         );
     }
-
-    @media (max-width: 768px) {
-        padding-left: 40px;
-        &::before {
-            left: 16px;
-            transform: none;
-        }
-    }
 `;
 
-const TimelineEntry = styled.div`
-    display: flex;
-    justify-content: ${({ $isLeft }) => ($isLeft ? 'flex-end' : 'flex-start')};
-    padding-bottom: 60px;
+const MobileEntry = styled.div`
     position: relative;
-
-    @media (max-width: 768px) {
-        justify-content: flex-start;
-        padding-bottom: 40px;
-    }
+    padding-bottom: 40px;
 `;
 
-const EntryCard = styled(motion.div)`
-    width: calc(50% - 52px);
-
-    @media (max-width: 768px) {
-        width: 100%;
-    }
-`;
-
-/* Glowing dot on the timeline */
-const Dot = styled.div`
+const MobileDot = styled.div`
     position: absolute;
-    left: 50%;
+    left: -32px;
     top: 30px;
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     border-radius: 50%;
     background: ${({ theme }) => theme.primary};
     border: 3px solid ${({ theme }) => theme.card_light};
     box-shadow:
-        0 0 0 4px ${({ theme }) => `${theme.primary}35`},
-        0 0 20px ${({ theme }) => `${theme.primary}50`};
-    transform: translateX(-50%);
+        0 0 0 3px ${({ theme }) => `${theme.primary}35`},
+        0 0 16px ${({ theme }) => `${theme.primary}50`};
     z-index: 2;
-
-    @media (max-width: 768px) {
-        left: 16px;
-    }
 `;
 
-/* Horizontal connector line from dot to card */
-const Connector = styled.div`
-    position: absolute;
-    top: 37px;
-    height: 2px;
-    width: 36px;
-    background: ${({ theme }) => `${theme.primary}50`};
-    ${({ $isLeft }) => $isLeft ? 'right: calc(50% + 16px);' : 'left: calc(50% + 16px);'}
-
-    @media (max-width: 768px) {
-        display: none;
-    }
-`;
+/* ── Component ── */
 
 const Experience = () => {
     const { data: experiences = [], loading } = useContent('experience');
+    const isMobile = useIsMobile();
+    const containerRef = useRef(null);
+    const [activeIndex, setActiveIndex] = useState(0);
 
+    const { scrollYProgress } = useScroll({
+        target: containerRef,
+        offset: ['start start', 'end end'],
+    });
+
+    const count = experiences.length || 1;
+    const x = useTransform(scrollYProgress, [0, 1], ['0vw', `${-(count - 1) * 100}vw`]);
+
+    useMotionValueEvent(scrollYProgress, 'change', v => {
+        const idx = Math.floor(v * count);
+        setActiveIndex(Math.min(count - 1, Math.max(0, idx)));
+    });
+
+    if (loading) return null;
+
+    /* Mobile layout */
+    if (isMobile) {
+        return (
+            <Outer id="experience">
+                <MobileContainer>
+                    <MobileWrapper>
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            whileInView={{ opacity: 1, y: 0 }}
+                            viewport={{ once: true, amount: 0.2 }}
+                            transition={{ duration: 0.5 }}
+                            style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', marginBottom: '32px' }}
+                        >
+                            <SectionHeadingWrapper>
+                                <SectionLabel>My Journey</SectionLabel>
+                                <SectionTitle>Experience</SectionTitle>
+                            </SectionHeadingWrapper>
+                        </motion.div>
+
+                        {experiences.length > 0 && (
+                            <MobileTimeline>
+                                {experiences.map((exp, i) => (
+                                    <MobileEntry key={i}>
+                                        <MobileDot />
+                                        <motion.div
+                                            initial={{ opacity: 0, x: -30 }}
+                                            whileInView={{ opacity: 1, x: 0 }}
+                                            viewport={{ once: true, amount: 0.1 }}
+                                            transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+                                        >
+                                            <ExperienceCard experience={exp} />
+                                        </motion.div>
+                                    </MobileEntry>
+                                ))}
+                            </MobileTimeline>
+                        )}
+                    </MobileWrapper>
+                </MobileContainer>
+            </Outer>
+        );
+    }
+
+    /* Desktop horizontal scroll */
     return (
-        <Container id="experience">
-            <Wrapper>
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    viewport={{ once: true, amount: 0.2 }}
-                    transition={{ duration: 0.5 }}
-                    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
-                >
-                    <SectionHeadingWrapper>
-                        <SectionLabel>My Journey</SectionLabel>
-                        <SectionTitle>Experience</SectionTitle>
-                    </SectionHeadingWrapper>
-                    <SectionDesc>
-                        The roles and projects that have shaped my skills and perspective as a developer.
-                    </SectionDesc>
-                </motion.div>
+        <Outer id="experience">
+            <ScrollSpace ref={containerRef} $count={count}>
+                <StickyWrap>
+                    <ProgressTrack>
+                        <ProgressFill style={{ scaleX: scrollYProgress }} />
+                    </ProgressTrack>
 
-                {!loading && experiences.length > 0 && (
-                    <Timeline>
-                        {experiences.map((exp, index) => {
-                            const isLeft = index % 2 === 0;
-                            return (
-                                <TimelineEntry key={index} $isLeft={isLeft}>
-                                    <Dot />
-                                    <Connector $isLeft={isLeft} />
-                                    <EntryCard
-                                        initial={{ opacity: 0, x: isLeft ? -50 : 50 }}
-                                        whileInView={{ opacity: 1, x: 0 }}
-                                        viewport={{ once: true, amount: 0.15 }}
-                                        transition={{
-                                            duration: 0.55,
-                                            ease: [0.16, 1, 0.3, 1],
-                                        }}
-                                    >
-                                        <ExperienceCard experience={exp} />
-                                    </EntryCard>
-                                </TimelineEntry>
-                            );
-                        })}
-                    </Timeline>
-                )}
-            </Wrapper>
-        </Container>
+                    <HeaderArea>
+                        <SectionHeadingWrapper style={{ marginBottom: 0 }}>
+                            <SectionLabel>My Journey</SectionLabel>
+                            <SectionTitle>Experience</SectionTitle>
+                        </SectionHeadingWrapper>
+                    </HeaderArea>
+
+                    <Track style={{ x }}>
+                        {experiences.map((exp, i) => (
+                            <Panel key={i}>
+                                <PanelInner>
+                                    <Left>
+                                        <IndexWatermark>
+                                            {String(i + 1).padStart(2, '0')}
+                                        </IndexWatermark>
+                                        <LogoBox>
+                                            <Logo src={exp.img} alt={exp.company} />
+                                        </LogoBox>
+                                        <Role>{exp.role}</Role>
+                                        <CompanyName>
+                                            {exp.companyUrl ? (
+                                                <CompanyLink href={exp.companyUrl} target="_blank" rel="noopener noreferrer">
+                                                    {exp.company}
+                                                    <FaExternalLinkAlt size={11} />
+                                                </CompanyLink>
+                                            ) : exp.company}
+                                        </CompanyName>
+                                        <MetaRow>
+                                            <MetaItem>
+                                                <FaCalendarAlt size={12} />
+                                                {exp.date}
+                                            </MetaItem>
+                                            {exp.location && (
+                                                <MetaItem>
+                                                    <FaMapMarkerAlt size={12} />
+                                                    {exp.location}
+                                                </MetaItem>
+                                            )}
+                                        </MetaRow>
+                                    </Left>
+
+                                    <Right>
+                                        {exp.desc && (
+                                            <Description
+                                                dangerouslySetInnerHTML={{
+                                                    __html: exp.desc.replace(/\n/g, '<br />')
+                                                }}
+                                            />
+                                        )}
+
+                                        {exp.skills?.length > 0 && (
+                                            <SkillsWrap>
+                                                <SkillsLabel>Technologies</SkillsLabel>
+                                                <SkillList>
+                                                    {exp.skills.map((s, j) => (
+                                                        <SkillPill key={j}>{s}</SkillPill>
+                                                    ))}
+                                                </SkillList>
+                                            </SkillsWrap>
+                                        )}
+
+                                        {(exp.doc || exp.pdf || exp.additionalResources?.length > 0) && (
+                                            <LinksRow>
+                                                {exp.doc && (
+                                                    <LinkBtn href={exp.doc} target="_blank" rel="noopener noreferrer">
+                                                        <FaExternalLinkAlt size={11} /> View Certificate
+                                                    </LinkBtn>
+                                                )}
+                                                {exp.pdf && (
+                                                    <LinkBtn href={exp.pdf} target="_blank" rel="noopener noreferrer">
+                                                        <FaExternalLinkAlt size={11} /> View PDF
+                                                    </LinkBtn>
+                                                )}
+                                                {exp.additionalResources?.map((r, j) => (
+                                                    <LinkBtn key={j} href={r.url} target="_blank" rel="noopener noreferrer">
+                                                        {r.icon} {r.title}
+                                                    </LinkBtn>
+                                                ))}
+                                            </LinksRow>
+                                        )}
+                                    </Right>
+                                </PanelInner>
+                            </Panel>
+                        ))}
+                    </Track>
+
+                    <NavBar>
+                        <Dots>
+                            {experiences.map((_, i) => (
+                                <NavDot key={i} $active={i === activeIndex} />
+                            ))}
+                        </Dots>
+                        <ScrollHint
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: activeIndex === count - 1 ? 0 : 1 }}
+                            transition={{ duration: 0.4 }}
+                        >
+                            Scroll to continue
+                            <HintLine />
+                        </ScrollHint>
+                        <SlideCount>
+                            {String(activeIndex + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
+                        </SlideCount>
+                    </NavBar>
+                </StickyWrap>
+            </ScrollSpace>
+        </Outer>
     );
 };
 

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -32,14 +32,15 @@ const ScrollSpace = styled.div`
     position: relative;
 `;
 
+const NAVBAR_H = 80;
+
 const StickyWrap = styled.div`
     position: sticky;
-    top: 0;
-    height: 100vh;
+    top: ${NAVBAR_H}px;
+    height: calc(100vh - ${NAVBAR_H}px);
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    isolation: isolate;
 `;
 
 const ProgressTrack = styled.div`
@@ -64,15 +65,14 @@ const HeaderArea = styled.div`
 
 const Track = styled(motion.div)`
     display: flex;
+    flex: 1;
+    min-height: 0;
     width: ${({ $count }) => $count * 100}vw;
-    flex-shrink: 0;
-    align-self: stretch;
     will-change: transform;
 `;
 
 const Panel = styled.div`
-    min-width: 100vw;
-    width: 100vw;
+    flex: 0 0 100vw;
     height: 100%;
     display: flex;
     align-items: center;
@@ -375,12 +375,27 @@ const Experience = () => {
         return () => window.removeEventListener('resize', onResize);
     }, []);
 
-    const { scrollYProgress } = useScroll({
-        target: containerRef,
-        offset: ['start start', 'end end'],
-    });
+    const { scrollY } = useScroll();
+    const [scrollRange, setScrollRange] = useState([0, 1]);
 
     const count = experiences.length || 1;
+
+    useEffect(() => {
+        const el = containerRef.current;
+        if (!el || !experiences.length) return;
+        const measure = () => {
+            requestAnimationFrame(() => {
+                const rect = el.getBoundingClientRect();
+                const top = window.scrollY + rect.top;
+                setScrollRange([top, top + el.offsetHeight - window.innerHeight]);
+            });
+        };
+        measure();
+        window.addEventListener('resize', measure);
+        return () => window.removeEventListener('resize', measure);
+    }, [experiences.length]);
+
+    const scrollYProgress = useTransform(scrollY, scrollRange, [0, 1], { clamp: true });
     const x = useTransform(scrollYProgress, [0, 1], [0, -(count - 1) * vw]);
 
     useMotionValueEvent(scrollYProgress, 'change', v => {

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -1,9 +1,8 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import ExperienceCard from '../Cards/ExperienceCard';
 import useContent from '../../hooks/useContent';
-import {motion} from 'framer-motion';
-import {FaAngleRight, FaBriefcase} from 'react-icons/fa';
+import { motion } from 'framer-motion';
 import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from '../SectionTitle';
 
 const Container = styled.div`
@@ -24,166 +23,105 @@ const Container = styled.div`
 const Wrapper = styled.div`
     position: relative;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
     flex-direction: column;
+    align-items: center;
     width: 100%;
     max-width: 1100px;
-    padding: 40px 0;
-    gap: 12px;
-
-    @media (max-width: 960px) {
-        flex-direction: column;
-    }
+    padding: 0 20px;
+    gap: 0;
 `;
 
+/* ── Timeline ── */
 
-const ExperienceContainer = styled.div`
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    gap: 30px;
-    justify-content: center;
-    align-items: flex-start;
-    padding: 0 16px;
-
-    @media (max-width: 960px) {
-        flex-direction: column;
-        align-items: center;
-    }
-`;
-
-const TabsContainer = styled.div`
-    width: 300px;
-    display: flex;
-    flex-direction: column;
-    border-right: 1px solid ${({theme}) => `${theme.text_primary}20`};
-
-    @media (max-width: 960px) {
-    width: 100%;
-        max-width: 600px;
-        border-right: none;
-        border-bottom: 1px solid ${({theme}) => `${theme.text_primary}20`};
-        margin-bottom: 20px;
-        padding-bottom: 10px;
-        display: flex;
-        flex-direction: row;
-        overflow-x: auto;
-        white-space: nowrap;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none; /* Firefox */
-        &::-webkit-scrollbar {
-            display: none; /* Chrome, Safari, Edge */
-        }
-    }
-`;
-
-const Tab = styled.div`
-    padding: 16px 24px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
+const Timeline = styled.div`
     position: relative;
-    font-size: 16px;
-    color: ${({active, theme}) => active ? theme.primary : theme.text_secondary};
-    border-left: 3px solid ${({active, theme}) => active ? theme.primary : 'transparent'};
-    background-color: ${({active, theme}) => active ? `${theme.primary}10` : 'transparent'};
-    transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out, border-color 0.25s ease-in-out;
+    width: 100%;
+    padding: 48px 0 0;
 
-    &:hover {
-        color: ${({theme}) => theme.primary};
-        background-color: ${({theme}) => `${theme.primary}10`};
+    /* Vertical centre line */
+    &::before {
+        content: '';
+        position: absolute;
+        left: 50%;
+        top: 0;
+        bottom: 0;
+        width: 2px;
+        transform: translateX(-50%);
+        background: linear-gradient(
+            to bottom,
+            transparent,
+            ${({ theme }) => theme.primary}70 6%,
+            ${({ theme }) => theme.primary}70 94%,
+            transparent
+        );
     }
 
-    @media (max-width: 960px) {
-        padding: 10px 12px;
-        font-size: 14px;
-        border-left: none;
-        border-bottom: 3px solid ${({active, theme}) => active ? theme.primary : 'transparent'};
-        text-align: center;
-    justify-content: center;
+    @media (max-width: 768px) {
+        padding-left: 40px;
+        &::before {
+            left: 16px;
+            transform: none;
+        }
     }
 `;
 
-const TabIcon = styled.div`
+const TimelineEntry = styled.div`
     display: flex;
-    align-items: center;
-    margin-right: 12px;
+    justify-content: ${({ $isLeft }) => ($isLeft ? 'flex-end' : 'flex-start')};
+    padding-bottom: 60px;
+    position: relative;
 
-    @media (max-width: 960px) {
-        margin-right: 6px;
+    @media (max-width: 768px) {
+        justify-content: flex-start;
+        padding-bottom: 40px;
     }
 `;
 
-const TabContent = styled(motion.div)`
-    flex: 1;
-    max-width: 700px;
+const EntryCard = styled(motion.div)`
+    width: calc(50% - 52px);
 
-    @media (max-width: 960px) {
+    @media (max-width: 768px) {
         width: 100%;
-        max-width: 600px;
     }
 `;
 
-const CardContainer = styled(motion.div)`
-    padding: 10px;
+/* Glowing dot on the timeline */
+const Dot = styled.div`
+    position: absolute;
+    left: 50%;
+    top: 30px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.primary};
+    border: 3px solid ${({ theme }) => theme.card_light};
+    box-shadow:
+        0 0 0 4px ${({ theme }) => `${theme.primary}35`},
+        0 0 20px ${({ theme }) => `${theme.primary}50`};
+    transform: translateX(-50%);
+    z-index: 2;
+
+    @media (max-width: 768px) {
+        left: 16px;
+    }
 `;
 
-// Animation variants for tab content
-const contentVariants = {
-    hidden: {opacity: 0, x: 20},
-    visible: {
-        opacity: 1,
-        x: 0,
-        transition: {
-            duration: 0.5,
-            ease: "easeInOut"
-        }
-    },
-    exit: {
-        opacity: 0,
-        x: -20,
-        transition: {
-            duration: 0.3
-        }
+/* Horizontal connector line from dot to card */
+const Connector = styled.div`
+    position: absolute;
+    top: 37px;
+    height: 2px;
+    width: 36px;
+    background: ${({ theme }) => `${theme.primary}50`};
+    ${({ $isLeft }) => $isLeft ? 'right: calc(50% + 16px);' : 'left: calc(50% + 16px);'}
+
+    @media (max-width: 768px) {
+        display: none;
     }
-};
+`;
 
 const Experience = () => {
-    const [activeTab, setActiveTab] = useState(0);
     const { data: experiences = [], loading } = useContent('experience');
-    const currentExperience = experiences[activeTab] || experiences[0];
-
-    // For managing additional resources
-    const [resources, setResources] = useState([]);
-
-    // Load resources when tab changes
-    useEffect(() => {
-        if (experiences[activeTab]?.additionalResources) {
-            setResources(
-                experiences[activeTab].additionalResources.map(resource => ({
-                    type: getResourceType(resource),
-                    title: resource.title,
-                    url: resource.url
-                }))
-            );
-        } else {
-            setResources([]);
-        }
-    }, [activeTab, experiences]);
-
-    // Helper to determine resource type from icon
-    const getResourceType = (resource) => {
-        const icon = resource.icon?.type?.name;
-        if (icon === "FaGooglePlay") return "playstore";
-        if (icon === "FaAppStore") return "appstore";
-        if (icon === "FaGithub") return "github";
-        return "website";
-    };
-
-    const handleTabClick = (index) => {
-        setActiveTab(index);
-    };
 
     return (
         <Container id="experience">
@@ -193,50 +131,41 @@ const Experience = () => {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true, amount: 0.2 }}
                     transition={{ duration: 0.5 }}
-                    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
                 >
-                <SectionHeadingWrapper>
-                    <SectionLabel>My Journey</SectionLabel>
-                    <SectionTitle>Experience</SectionTitle>
-                </SectionHeadingWrapper>
-                <SectionDesc>
-                    My professional journey as a software engineer, working with different companies and on various
-                    projects. These experiences have helped me grow and develop my skills in different technologies and
-                    environments.
-                </SectionDesc>
+                    <SectionHeadingWrapper>
+                        <SectionLabel>My Journey</SectionLabel>
+                        <SectionTitle>Experience</SectionTitle>
+                    </SectionHeadingWrapper>
+                    <SectionDesc>
+                        The roles and projects that have shaped my skills and perspective as a developer.
+                    </SectionDesc>
                 </motion.div>
 
-                <ExperienceContainer>
-                    <TabsContainer numTabs={experiences.length}>
-                        {experiences.map((experience, index) => (
-                            <Tab
-                                key={index}
-                                active={activeTab === index}
-                                onClick={() => handleTabClick(index)}
-                            >
-                                <TabIcon>
-                                    <FaBriefcase/>
-                                </TabIcon>
-                                {experience.company || experience.title}
-                                {activeTab === index && <FaAngleRight style={{marginLeft: 'auto'}}/>}
-                            </Tab>
-                        ))}
-                    </TabsContainer>
-
-                    <TabContent
-                        key={activeTab}
-                        initial="hidden"
-                        animate="visible"
-                        exit="exit"
-                        variants={contentVariants}
-                    >
-                        <CardContainer>
-                            {!loading && currentExperience && (
-                              <ExperienceCard experience={currentExperience}/>
-                            )}
-                        </CardContainer>
-                    </TabContent>
-                </ExperienceContainer>
+                {!loading && experiences.length > 0 && (
+                    <Timeline>
+                        {experiences.map((exp, index) => {
+                            const isLeft = index % 2 === 0;
+                            return (
+                                <TimelineEntry key={index} $isLeft={isLeft}>
+                                    <Dot />
+                                    <Connector $isLeft={isLeft} />
+                                    <EntryCard
+                                        initial={{ opacity: 0, x: isLeft ? -50 : 50 }}
+                                        whileInView={{ opacity: 1, x: 0 }}
+                                        viewport={{ once: true, amount: 0.15 }}
+                                        transition={{
+                                            duration: 0.55,
+                                            ease: [0.16, 1, 0.3, 1],
+                                        }}
+                                    >
+                                        <ExperienceCard experience={exp} />
+                                    </EntryCard>
+                                </TimelineEntry>
+                            );
+                        })}
+                    </Timeline>
+                )}
             </Wrapper>
         </Container>
     );

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -39,6 +39,7 @@ const StickyWrap = styled.div`
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    isolation: isolate;
 `;
 
 const ProgressTrack = styled.div`
@@ -63,9 +64,10 @@ const HeaderArea = styled.div`
 
 const Track = styled(motion.div)`
     display: flex;
-    flex: 1;
+    width: ${({ $count }) => $count * 100}vw;
+    flex-shrink: 0;
+    align-self: stretch;
     will-change: transform;
-    min-height: 0;
 `;
 
 const Panel = styled.div`
@@ -363,6 +365,15 @@ const Experience = () => {
     const isMobile = useIsMobile();
     const containerRef = useRef(null);
     const [activeIndex, setActiveIndex] = useState(0);
+    const [vw, setVw] = useState(() =>
+        typeof window !== 'undefined' ? window.innerWidth : 1200
+    );
+
+    useEffect(() => {
+        const onResize = () => setVw(window.innerWidth);
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
+    }, []);
 
     const { scrollYProgress } = useScroll({
         target: containerRef,
@@ -370,7 +381,7 @@ const Experience = () => {
     });
 
     const count = experiences.length || 1;
-    const x = useTransform(scrollYProgress, [0, 1], ['0vw', `${-(count - 1) * 100}vw`]);
+    const x = useTransform(scrollYProgress, [0, 1], [0, -(count - 1) * vw]);
 
     useMotionValueEvent(scrollYProgress, 'change', v => {
         const idx = Math.floor(v * count);
@@ -437,7 +448,7 @@ const Experience = () => {
                         </SectionHeadingWrapper>
                     </HeaderArea>
 
-                    <Track style={{ x }}>
+                    <Track style={{ x }} $count={count}>
                         {experiences.map((exp, i) => (
                             <Panel key={i}>
                                 <PanelInner>

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -88,7 +88,7 @@ const Tab = styled.div`
     color: ${({active, theme}) => active ? theme.primary : theme.text_secondary};
     border-left: 3px solid ${({active, theme}) => active ? theme.primary : 'transparent'};
     background-color: ${({active, theme}) => active ? `${theme.primary}10` : 'transparent'};
-    transition: all 0.3s ease-in-out;
+    transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out, border-color 0.25s ease-in-out;
 
     &:hover {
         color: ${({theme}) => theme.primary};

--- a/src/components/Experience/index.js
+++ b/src/components/Experience/index.js
@@ -113,7 +113,7 @@ const Connector = styled.div`
     height: 2px;
     width: 36px;
     background: ${({ theme }) => `${theme.primary}50`};
-    ${({ $isLeft }) => $isLeft ? 'right: calc(50% + 16px);' : 'left: calc(50% + 16px);'}
+    ${({ $isLeft }) => $isLeft ? 'left: calc(50% + 16px);' : 'right: calc(50% + 16px);'}
 
     @media (max-width: 768px) {
         display: none;

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,10 +1,21 @@
-// Update your Footer component to include the Certificates link
-
 import React from "react";
 import styled from "styled-components";
 import { FaLinkedin, FaGithub, FaEnvelope } from "react-icons/fa";
 import { FiArrowUp } from "react-icons/fi";
 import { Bio } from "../../data/constants";
+
+const WaveWrapper = styled.div`
+  width: 100%;
+  overflow: hidden;
+  line-height: 0;
+  background: ${({ theme }) => theme.card_light};
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 60px;
+  }
+`;
 
 const FooterContainer = styled.div`
   width: 100%;
@@ -12,11 +23,6 @@ const FooterContainer = styled.div`
   display: flex;
   justify-content: center;
   background: ${({ theme }) => theme.card_light};
-  background: linear-gradient(
-    to bottom,
-    ${({ theme }) => theme.bg} 0%,
-    ${({ theme }) => theme.card_light} 100%
-  );
   position: relative;
   z-index: 1;
 `;
@@ -237,6 +243,16 @@ const Footer = () => {
   };
 
   return (
+      <>
+      <WaveWrapper>
+        <svg viewBox="0 0 1440 60" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <path
+            d="M0,40 C360,80 1080,0 1440,40 L1440,60 L0,60 Z"
+            fill="currentColor"
+            style={{ color: 'inherit' }}
+          />
+        </svg>
+      </WaveWrapper>
       <FooterContainer>
         <FooterWrapper>
           <ScrollToTop onClick={scrollToTop}>
@@ -306,6 +322,7 @@ const Footer = () => {
           </Copyright>
         </FooterWrapper>
       </FooterContainer>
+      </>
   );
 };
 

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,9 +1,12 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { FaLinkedin, FaGithub, FaEnvelope } from "react-icons/fa";
 import { FiArrowUp } from "react-icons/fi";
 import { Bio } from "../../data/constants";
 
+// WaveWrapper background matches the Contact section (card_light),
+// so the wave looks like a bite taken out of that section.
+// The SVG fill must match the footer background (bg).
 const WaveWrapper = styled.div`
   width: 100%;
   overflow: hidden;
@@ -22,7 +25,7 @@ const FooterContainer = styled.div`
   padding: 2rem 0;
   display: flex;
   justify-content: center;
-  background: ${({ theme }) => theme.card_light};
+  background: ${({ theme }) => theme.bg};
   position: relative;
   z-index: 1;
 `;
@@ -114,7 +117,7 @@ const SocialMediaIcon = styled.a`
   border-radius: 50%;
   width: 40px;
   height: 40px;
-  background: ${({ theme }) => `${theme.card_light}90`};
+  background: ${({ theme }) => `${theme.primary}15`};
   
   &:hover {
     color: ${({ theme }) => theme.primary};
@@ -235,6 +238,7 @@ const FooterLink = styled.a`
 `;
 
 const Footer = () => {
+  const theme = useTheme();
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
@@ -248,8 +252,7 @@ const Footer = () => {
         <svg viewBox="0 0 1440 60" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
           <path
             d="M0,40 C360,80 1080,0 1440,40 L1440,60 L0,60 Z"
-            fill="currentColor"
-            style={{ color: 'inherit' }}
+            fill={theme.bg}
           />
         </svg>
       </WaveWrapper>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -141,10 +141,16 @@ const EasterEggHint = styled.p`
   margin-top: 10px;
   letter-spacing: 1px;
   user-select: none;
+  cursor: pointer;
   transition: opacity 0.3s ease;
 
   &:hover {
-    opacity: 0.55;
+    opacity: 0.6;
+  }
+
+  @media (max-width: 768px) {
+    opacity: 0.28;
+    font-size: 12px;
   }
 `;
 
@@ -252,7 +258,7 @@ const FooterLink = styled.a`
   }
 `;
 
-const Footer = () => {
+const Footer = ({ onEasterEgg }) => {
   const theme = useTheme();
   const scrollToTop = () => {
     window.scrollTo({
@@ -338,7 +344,7 @@ const Footer = () => {
           <Copyright>
             &copy; {new Date().getFullYear()} Jakub Olszewski. All rights reserved.
           </Copyright>
-          <EasterEggHint>// ↑ ↑ ↓ ↓ ← → ← → B A</EasterEggHint>
+          <EasterEggHint onClick={onEasterEgg}>// ↑ ↑ ↓ ↓ ← → ← → B A</EasterEggHint>
         </FooterWrapper>
       </FooterContainer>
       </>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -133,6 +133,21 @@ const Copyright = styled.p`
   text-align: center;
 `;
 
+const EasterEggHint = styled.p`
+  font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: ${({ theme }) => theme.text_secondary};
+  opacity: 0.18;
+  margin-top: 10px;
+  letter-spacing: 1px;
+  user-select: none;
+  transition: opacity 0.3s ease;
+
+  &:hover {
+    opacity: 0.55;
+  }
+`;
+
 const ScrollToTop = styled.div`
   position: absolute;
   top: -25px;
@@ -323,6 +338,7 @@ const Footer = () => {
           <Copyright>
             &copy; {new Date().getFullYear()} Jakub Olszewski. All rights reserved.
           </Copyright>
+          <EasterEggHint>// ↑ ↑ ↓ ↓ ← → ← → B A</EasterEggHint>
         </FooterWrapper>
       </FooterContainer>
       </>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -45,8 +45,8 @@ const Logo = styled.h1`
   font-weight: 700;
   font-size: 28px;
   color: ${({ theme }) => theme.primary};
-  transition: all 0.3s ease-in-out;
-  
+  transition: transform 0.3s ease-in-out;
+
   &:hover {
     transform: scale(1.05);
   }
@@ -74,7 +74,7 @@ const NavLink = styled.a`
   color: ${({ theme }) => theme.text_primary};
   text-decoration: none;
   font-size: 1.2rem;
-  transition: all 0.3s ease-in-out;
+  transition: color 0.3s ease-in-out;
   position: relative;
   
   &:after {
@@ -113,12 +113,12 @@ const SocialMediaIcon = styled.a`
   justify-content: center;
   color: ${({ theme }) => theme.text_primary};
   font-size: 1.5rem;
-  transition: all 0.3s ease-in-out;
+  transition: color 0.3s ease-in-out, transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
   border-radius: 50%;
   width: 40px;
   height: 40px;
   background: ${({ theme }) => `${theme.primary}15`};
-  
+
   &:hover {
     color: ${({ theme }) => theme.primary};
     transform: translateY(-3px);
@@ -148,13 +148,13 @@ const ScrollToTop = styled.div`
   font-size: 24px;
   cursor: pointer;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
-  transition: all 0.3s ease-in-out;
-  
+  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+
   &:hover {
     transform: translateY(-5px);
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
   }
-  
+
   @media (max-width: 768px) {
     right: 20px;
     width: 45px;
@@ -229,8 +229,8 @@ const FooterLink = styled.a`
   color: ${({ theme }) => theme.text_secondary};
   text-decoration: none;
   font-size: 14px;
-  transition: all 0.3s ease-in-out;
-  
+  transition: color 0.3s ease-in-out, transform 0.3s ease-in-out;
+
   &:hover {
     color: ${({ theme }) => theme.primary};
     transform: translateX(3px);

--- a/src/components/HeroSection/HeroStyle.js
+++ b/src/components/HeroSection/HeroStyle.js
@@ -1,14 +1,16 @@
 import styled, { keyframes } from "styled-components";
 
 const fadeIn = keyframes`
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+    from { opacity: 0; transform: translateY(20px); }
+    to   { opacity: 1; transform: translateY(0); }
+`;
+
+const auroraShift = keyframes`
+    0%   { transform: translate(0%,   0%)   scale(1);    }
+    25%  { transform: translate(-4%,  5%)   scale(1.06); }
+    50%  { transform: translate(5%,  -3%)   scale(0.97); }
+    75%  { transform: translate(-2%, -5%)   scale(1.04); }
+    100% { transform: translate(0%,   0%)   scale(1);    }
 `;
 
 // Combined float + glow in one keyframe — eliminates the jitter from
@@ -46,7 +48,21 @@ const bounce = keyframes`
 
 export const HeroSectionWrapper = styled.div`
     position: relative;
-    padding-top: 80px; // Account for the fixed navbar
+    padding-top: 80px;
+    overflow: hidden;
+`;
+
+export const AuroraBg = styled.div`
+    position: absolute;
+    inset: -40%;
+    z-index: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse 80% 60% at 15% 45%, rgba(47, 129, 247, 0.26) 0%, transparent 65%),
+        radial-gradient(ellipse 60% 80% at 85% 25%, rgba(14, 165, 233, 0.2)  0%, transparent 60%),
+        radial-gradient(ellipse 70% 50% at 55% 80%, rgba(99, 102, 241, 0.14) 0%, transparent 60%);
+    animation: ${auroraShift} 18s ease-in-out infinite alternate;
+    will-change: transform;
 `;
 
 export const HeroContainer = styled.div`
@@ -341,8 +357,70 @@ export const ScrollDownIcon = styled.div`
   color: ${({ theme }) => theme.text_secondary};
   cursor: pointer;
   transition: color 0.3s ease-in-out;
-  
+
   &:hover {
     color: ${({ theme }) => theme.primary};
   }
+`;
+
+/* ── Hero stats ── */
+
+export const StatsRow = styled.div`
+  display: flex;
+  gap: 36px;
+  margin-top: 36px;
+  flex-wrap: wrap;
+
+  @media (max-width: 960px) {
+    justify-content: center;
+    gap: 28px;
+  }
+
+  @media (max-width: 480px) {
+    gap: 20px;
+  }
+`;
+
+export const StatItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  position: relative;
+
+  &:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    right: -18px;
+    top: 8px;
+    height: 32px;
+    width: 1px;
+    background: ${({ theme }) => `${theme.text_primary}20`};
+
+    @media (max-width: 960px) {
+      display: none;
+    }
+  }
+
+  @media (max-width: 960px) {
+    align-items: center;
+  }
+`;
+
+export const StatNumber = styled.div`
+  font-size: 38px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -1.5px;
+  background: linear-gradient(135deg, #2F81F7, #0EA5E9);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+`;
+
+export const StatLabel = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.text_secondary};
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
 `;

--- a/src/components/HeroSection/HeroStyle.js
+++ b/src/components/HeroSection/HeroStyle.js
@@ -34,6 +34,12 @@ const floatGlow = keyframes`
 `;
 
 
+const pulseRing = keyframes`
+    0%   { transform: scale(1);   opacity: 0.7; }
+    70%  { transform: scale(2.2); opacity: 0;   }
+    100% { transform: scale(2.2); opacity: 0;   }
+`;
+
 const bounce = keyframes`
     0%, 20%, 50%, 80%, 100% {
         transform: translateY(0);
@@ -423,4 +429,43 @@ export const StatLabel = styled.div`
   color: ${({ theme }) => theme.text_secondary};
   text-transform: uppercase;
   letter-spacing: 0.8px;
+`;
+
+export const AvailableBadge = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 50px;
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  font-size: 13px;
+  font-weight: 600;
+  color: #22c55e;
+  letter-spacing: 0.3px;
+  margin-bottom: 20px;
+  width: fit-content;
+
+  @media (max-width: 960px) {
+    align-self: center;
+  }
+`;
+
+export const PulseDot = styled.span`
+  position: relative;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  flex-shrink: 0;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: #22c55e;
+    animation: ${pulseRing} 1.8s ease-out infinite;
+  }
 `;

--- a/src/components/HeroSection/HeroStyle.js
+++ b/src/components/HeroSection/HeroStyle.js
@@ -11,6 +11,18 @@ const fadeIn = keyframes`
     }
 `;
 
+const glowPulse = keyframes`
+    0% {
+        box-shadow: 0 0 0 0 rgba(47, 129, 247, 0.4), 0 10px 20px rgba(0, 0, 0, 0.15);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(47, 129, 247, 0), 0 10px 20px rgba(0, 0, 0, 0.15);
+    }
+    100% {
+        box-shadow: 0 0 0 0 rgba(47, 129, 247, 0), 0 10px 20px rgba(0, 0, 0, 0.15);
+    }
+`;
+
 const float = keyframes`
     0% {
         transform: translateY(0px);
@@ -46,17 +58,16 @@ export const HeroContainer = styled.div`
     flex-direction: column;
     justify-content: center;
     position: relative;
-    padding: 120px 30px 80px;
+    padding: 120px 30px 100px;
     z-index: 1;
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 70% 95%, 0 100%);
     transition: all 0.5s ease-in-out;
     opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
 
     @media (max-width: 960px) {
-        padding: 66px 16px;
+        padding: 66px 16px 80px;
     }
     @media (max-width: 640px) {
-        padding: 32px 16px;
+        padding: 32px 16px 60px;
     }
 `;
 
@@ -144,14 +155,13 @@ export const Img = styled.img`
     max-height: 500px;
     border-radius: 50%;
     border: 4px solid ${({ theme }) => theme.primary};
-    animation: ${float} 6s ease-in-out infinite;
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+    animation: ${float} 6s ease-in-out infinite, ${glowPulse} 3s ease-in-out infinite;
     transition: all 0.5s ease-in-out;
 
     &:hover {
         transform: scale(1.03);
         border-color: ${({ theme }) => theme.primary};
-        box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
+        box-shadow: 0 20px 40px rgba(47, 129, 247, 0.35);
     }
 
     @media (max-width: 768px) {
@@ -204,12 +214,15 @@ export const TextLoop = styled.div`
 `;
 
 export const Span = styled.span`
-  color: ${({ theme }) => theme.primary};
+  background: linear-gradient(135deg, #2F81F7, #0EA5E9);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
   cursor: pointer;
-  transition: color 0.3s ease-in-out;
-  
+  transition: opacity 0.3s ease-in-out;
+
   &:hover {
-    color: ${({ theme }) => `${theme.primary}CC`}; // Adding transparency for hover effect
+    opacity: 0.85;
   }
 `;
 
@@ -231,37 +244,71 @@ export const SubTitle = styled.p`
   }
 `;
 
+export const ButtonRow = styled.div`
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    flex-wrap: wrap;
+
+    @media (max-width: 960px) {
+        justify-content: center;
+    }
+`;
+
 export const ResumeButton = styled.a`
     appearance: button;
     text-decoration: none;
-    width: 95%;
-    max-width: 250px;
-    text-align: center;
-    padding: 16px 0;
+    padding: 14px 32px;
     color: ${({ theme }) => theme.white};
     border-radius: 50px;
     cursor: pointer;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 600;
     transition: all 0.3s ease-in-out !important;
-    background: ${({ theme }) => theme.primary};
-    background: linear-gradient(225deg, 
-      ${({ theme }) => theme.primary} 0%, 
-      ${({ theme }) => `${theme.primary}CC`} 100%);
-    box-shadow: 0 6px 20px rgba(133, 76, 230, 0.25);
-    
+    background: linear-gradient(135deg, #2F81F7 0%, #0EA5E9 100%);
+    box-shadow: 0 6px 20px rgba(47, 129, 247, 0.35);
+
     &:hover {
         transform: translateY(-3px) scale(1.02);
-        box-shadow: 0 10px 25px rgba(133, 76, 230, 0.4);
+        box-shadow: 0 12px 28px rgba(47, 129, 247, 0.5);
     }
-    
+
     &:active {
         transform: translateY(1px) scale(0.98);
     }
-    
+
     @media (max-width: 640px) {
-        padding: 12px 0;
-        font-size: 16px;
+        padding: 12px 24px;
+        font-size: 15px;
+    }
+`;
+
+export const ContactButton = styled.a`
+    appearance: button;
+    text-decoration: none;
+    padding: 14px 32px;
+    color: ${({ theme }) => theme.primary};
+    border-radius: 50px;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: 600;
+    transition: all 0.3s ease-in-out !important;
+    background: transparent;
+    border: 2px solid ${({ theme }) => theme.primary};
+
+    &:hover {
+        background: ${({ theme }) => `${theme.primary}15`};
+        transform: translateY(-3px) scale(1.02);
+        box-shadow: 0 8px 20px rgba(47, 129, 247, 0.2);
+    }
+
+    &:active {
+        transform: translateY(1px) scale(0.98);
+    }
+
+    @media (max-width: 640px) {
+        padding: 12px 24px;
+        font-size: 15px;
     }
 `;
 

--- a/src/components/HeroSection/HeroStyle.js
+++ b/src/components/HeroSection/HeroStyle.js
@@ -11,29 +11,26 @@ const fadeIn = keyframes`
     }
 `;
 
-const glowPulse = keyframes`
+// Combined float + glow in one keyframe — eliminates the jitter from
+// two unsynchronised animations running on the same element.
+const floatGlow = keyframes`
     0% {
-        box-shadow: 0 0 0 0 rgba(47, 129, 247, 0.4), 0 10px 20px rgba(0, 0, 0, 0.15);
+        transform: translateY(0px);
+        box-shadow: 0 10px 20px rgba(0,0,0,0.15), 0 0 0 0 rgba(47,129,247,0.35);
+    }
+    30% {
+        box-shadow: 0 10px 20px rgba(0,0,0,0.15), 0 0 0 8px rgba(47,129,247,0);
     }
     50% {
-        box-shadow: 0 0 0 8px rgba(47, 129, 247, 0), 0 10px 20px rgba(0, 0, 0, 0.15);
+        transform: translateY(-12px);
+        box-shadow: 0 20px 30px rgba(0,0,0,0.2), 0 0 0 0 rgba(47,129,247,0);
     }
     100% {
-        box-shadow: 0 0 0 0 rgba(47, 129, 247, 0), 0 10px 20px rgba(0, 0, 0, 0.15);
+        transform: translateY(0px);
+        box-shadow: 0 10px 20px rgba(0,0,0,0.15), 0 0 0 0 rgba(47,129,247,0);
     }
 `;
 
-const float = keyframes`
-    0% {
-        transform: translateY(0px);
-    }
-    50% {
-        transform: translateY(-10px);
-    }
-    100% {
-        transform: translateY(0px);
-    }
-`;
 
 const bounce = keyframes`
     0%, 20%, 50%, 80%, 100% {
@@ -74,18 +71,14 @@ export const HeroContainer = styled.div`
 export const HeroBg = styled.div`
     position: absolute;
     display: flex;
-    justify-content: end;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    justify-content: flex-end;
+    top: 50%;
+    left: 50%;
     width: 100%;
     height: 100%;
     max-width: 1360px;
     overflow: hidden;
     padding: 0 30px;
-    top: 50%;
-    left: 50%;
     -webkit-transform: translateX(-50%) translateY(-50%);
     transform: translateX(-50%) translateY(-50%);
 
@@ -113,6 +106,7 @@ export const HeroLeftContainer = styled.div`
     width: 50%;
     order: 1;
     animation: ${fadeIn} 1s ease-in-out;
+    animation-fill-mode: both;
 
     @media (max-width: 960px) {
         width: 100%;
@@ -155,13 +149,13 @@ export const Img = styled.img`
     max-height: 500px;
     border-radius: 50%;
     border: 4px solid ${({ theme }) => theme.primary};
-    animation: ${float} 6s ease-in-out infinite, ${glowPulse} 3s ease-in-out infinite;
-    transition: all 0.5s ease-in-out;
+    animation: ${floatGlow} 6s ease-in-out infinite;
+    transition: transform 0.4s ease-in-out, box-shadow 0.4s ease-in-out, border-color 0.3s;
 
     &:hover {
-        transform: scale(1.03);
-        border-color: ${({ theme }) => theme.primary};
-        box-shadow: 0 20px 40px rgba(47, 129, 247, 0.35);
+        animation-play-state: paused;
+        transform: scale(1.04);
+        box-shadow: 0 20px 40px rgba(47, 129, 247, 0.4);
     }
 
     @media (max-width: 768px) {

--- a/src/components/HeroSection/HeroStyle.js
+++ b/src/components/HeroSection/HeroStyle.js
@@ -57,7 +57,7 @@ export const HeroContainer = styled.div`
     position: relative;
     padding: 120px 30px 100px;
     z-index: 1;
-    transition: all 0.5s ease-in-out;
+    transition: opacity 0.5s ease-in-out;
     opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
 
     @media (max-width: 960px) {

--- a/src/components/HeroSection/index.js
+++ b/src/components/HeroSection/index.js
@@ -45,7 +45,7 @@ const HeroSection = () => {
                 </HeroBg>
                 <HeroInnerContainer>
                     <HeroLeftContainer>
-                        <Title>Hi, I am <br /> <Span>{Bio.name}</Span></Title>
+                        <Title>Hi, I'm <br /> <Span>{Bio.name}</Span></Title>
                         <TextLoop>
                             I am a
                             <Span>

--- a/src/components/HeroSection/index.js
+++ b/src/components/HeroSection/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import HeroBgAnimation from '../HeroBgAnimation'
 import {
     HeroContainer,
@@ -17,19 +17,46 @@ import {
     SocialMediaIcons,
     SocialMediaIcon,
     ScrollDownIcon,
-    HeroSectionWrapper
+    HeroSectionWrapper,
+    AuroraBg,
+    StatsRow,
+    StatItem,
+    StatNumber,
+    StatLabel,
 } from './HeroStyle'
 import HeroImg from '../../images/HeroImage.jpg'
 import Typewriter from 'typewriter-effect';
 import { Bio } from '../../data/constants';
 import { FaLinkedin, FaGithub } from 'react-icons/fa';
 import { FiArrowDown } from 'react-icons/fi';
+import { motion, useMotionValue, useTransform, animate, useInView } from 'framer-motion';
+
+/* Animated count-up number */
+const Counter = ({ value, suffix = '' }) => {
+    const count = useMotionValue(0);
+    const rounded = useTransform(count, (v) => Math.round(v));
+    const ref = useRef(null);
+    const inView = useInView(ref, { once: true });
+
+    useEffect(() => {
+        if (inView) {
+            animate(count, value, { duration: 2.2, ease: [0.16, 1, 0.3, 1] });
+        }
+    }, [inView, count, value]);
+
+    return (
+        <StatNumber>
+            <span ref={ref}>
+                <motion.span>{rounded}</motion.span>{suffix}
+            </span>
+        </StatNumber>
+    );
+};
 
 const HeroSection = () => {
     const [isVisible, setIsVisible] = useState(false);
 
     useEffect(() => {
-        // Fade in effect when component mounts
         setIsVisible(true);
     }, []);
 
@@ -39,11 +66,12 @@ const HeroSection = () => {
 
     return (
         <HeroSectionWrapper id="about">
+            <AuroraBg />
             <HeroContainer isVisible={isVisible}>
                 <HeroBg>
                     <HeroBgAnimation />
                 </HeroBg>
-                <HeroInnerContainer>
+                <HeroInnerContainer style={{ position: 'relative', zIndex: 1 }}>
                     <HeroLeftContainer>
                         <Title>Hi, I'm <br /> <Span>{Bio.name}</Span></Title>
                         <TextLoop>
@@ -61,14 +89,32 @@ const HeroSection = () => {
                             </Span>
                         </TextLoop>
                         <SubTitle>{Bio.description}</SubTitle>
+
                         <ButtonRow>
                             <ResumeButton href={Bio.resume} target='_blank' rel="noopener noreferrer">
                                 View Resume
                             </ResumeButton>
-                            <ContactButton href="#contact" onClick={(e) => { e.preventDefault(); document.getElementById('contact').scrollIntoView({ behavior: 'smooth' }); }}>
+                            <ContactButton
+                                href="#contact"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    document.getElementById('contact').scrollIntoView({ behavior: 'smooth' });
+                                }}
+                            >
                                 Contact Me
                             </ContactButton>
                         </ButtonRow>
+
+                        {Bio.stats?.length > 0 && (
+                            <StatsRow>
+                                {Bio.stats.map((stat, i) => (
+                                    <StatItem key={i}>
+                                        <Counter value={stat.value} suffix={stat.suffix} />
+                                        <StatLabel>{stat.label}</StatLabel>
+                                    </StatItem>
+                                ))}
+                            </StatsRow>
+                        )}
 
                         <SocialMediaIcons>
                             <SocialMediaIcon href={Bio.linkedin} target="_blank" rel="noopener noreferrer">
@@ -85,7 +131,7 @@ const HeroSection = () => {
                     </HeroRightContainer>
                 </HeroInnerContainer>
 
-                <ScrollDownIcon onClick={scrollToNextSection}>
+                <ScrollDownIcon onClick={scrollToNextSection} style={{ position: 'relative', zIndex: 1 }}>
                     <FiArrowDown />
                 </ScrollDownIcon>
             </HeroContainer>

--- a/src/components/HeroSection/index.js
+++ b/src/components/HeroSection/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useEffect, useState, useRef, useCallback } from 'react'
 import HeroBgAnimation from '../HeroBgAnimation'
 import {
     HeroContainer,
@@ -23,6 +23,8 @@ import {
     StatItem,
     StatNumber,
     StatLabel,
+    AvailableBadge,
+    PulseDot,
 } from './HeroStyle'
 import HeroImg from '../../images/HeroImage.jpg'
 import Typewriter from 'typewriter-effect';
@@ -53,6 +55,37 @@ const Counter = ({ value, suffix = '' }) => {
     );
 };
 
+/* Magnetic wrapper — pulls element toward cursor on hover */
+const Magnetic = ({ children, strength = 0.3 }) => {
+    const ref = useRef(null);
+
+    const onMouseMove = useCallback((e) => {
+        const el = ref.current;
+        if (!el) return;
+        const rect = el.getBoundingClientRect();
+        const dx = e.clientX - (rect.left + rect.width / 2);
+        const dy = e.clientY - (rect.top + rect.height / 2);
+        el.style.transform = `translate(${dx * strength}px, ${dy * strength}px)`;
+    }, [strength]);
+
+    const onMouseLeave = useCallback(() => {
+        if (ref.current) {
+            ref.current.style.transform = 'translate(0px, 0px)';
+        }
+    }, []);
+
+    return (
+        <span
+            ref={ref}
+            onMouseMove={onMouseMove}
+            onMouseLeave={onMouseLeave}
+            style={{ display: 'inline-block', transition: 'transform 0.35s cubic-bezier(0.23, 1, 0.32, 1)' }}
+        >
+            {children}
+        </span>
+    );
+};
+
 const HeroSection = () => {
     const [isVisible, setIsVisible] = useState(false);
 
@@ -73,6 +106,11 @@ const HeroSection = () => {
                 </HeroBg>
                 <HeroInnerContainer style={{ position: 'relative', zIndex: 1 }}>
                     <HeroLeftContainer>
+                        <AvailableBadge>
+                            <PulseDot />
+                            Available for opportunities
+                        </AvailableBadge>
+
                         <Title>Hi, I'm <br /> <Span>{Bio.name}</Span></Title>
                         <TextLoop>
                             I am a
@@ -91,18 +129,22 @@ const HeroSection = () => {
                         <SubTitle>{Bio.description}</SubTitle>
 
                         <ButtonRow>
-                            <ResumeButton href={Bio.resume} target='_blank' rel="noopener noreferrer">
-                                View Resume
-                            </ResumeButton>
-                            <ContactButton
-                                href="#contact"
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    document.getElementById('contact').scrollIntoView({ behavior: 'smooth' });
-                                }}
-                            >
-                                Contact Me
-                            </ContactButton>
+                            <Magnetic strength={0.25}>
+                                <ResumeButton href={Bio.resume} target='_blank' rel="noopener noreferrer">
+                                    View Resume
+                                </ResumeButton>
+                            </Magnetic>
+                            <Magnetic strength={0.25}>
+                                <ContactButton
+                                    href="#contact"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        document.getElementById('contact').scrollIntoView({ behavior: 'smooth' });
+                                    }}
+                                >
+                                    Contact Me
+                                </ContactButton>
+                            </Magnetic>
                         </ButtonRow>
 
                         {Bio.stats?.length > 0 && (

--- a/src/components/HeroSection/index.js
+++ b/src/components/HeroSection/index.js
@@ -12,6 +12,8 @@ import {
     Span,
     SubTitle,
     ResumeButton,
+    ContactButton,
+    ButtonRow,
     SocialMediaIcons,
     SocialMediaIcon,
     ScrollDownIcon,
@@ -59,9 +61,14 @@ const HeroSection = () => {
                             </Span>
                         </TextLoop>
                         <SubTitle>{Bio.description}</SubTitle>
-                        <ResumeButton href={Bio.resume} target='_blank' rel="noopener noreferrer">
-                            View Resume
-                        </ResumeButton>
+                        <ButtonRow>
+                            <ResumeButton href={Bio.resume} target='_blank' rel="noopener noreferrer">
+                                View Resume
+                            </ResumeButton>
+                            <ContactButton href="#contact" onClick={(e) => { e.preventDefault(); document.getElementById('contact').scrollIntoView({ behavior: 'smooth' }); }}>
+                                Contact Me
+                            </ContactButton>
+                        </ButtonRow>
 
                         <SocialMediaIcons>
                             <SocialMediaIcon href={Bio.linkedin} target="_blank" rel="noopener noreferrer">

--- a/src/components/IntroSplash.js
+++ b/src/components/IntroSplash.js
@@ -1,0 +1,114 @@
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import styled from 'styled-components';
+
+const Overlay = styled(motion.div)`
+    position: fixed;
+    inset: 0;
+    z-index: 99999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: ${({ theme }) => theme.bg};
+    overflow: hidden;
+`;
+
+const Initials = styled.div`
+    display: flex;
+    align-items: baseline;
+    gap: 0;
+    user-select: none;
+`;
+
+const GradientChar = styled(motion.span)`
+    font-size: clamp(80px, 14vw, 140px);
+    font-weight: 900;
+    line-height: 1;
+    background: linear-gradient(135deg, #2F81F7, #0EA5E9);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    display: inline-block;
+`;
+
+/* Characters that make up "J.O." and their burst direction */
+const CHARS = [
+    { char: 'J', burstY: -120, burstX: -80,  delay: 0 },
+    { char: '.', burstY:  40,  burstX: -60,  delay: 0.08 },
+    { char: 'O', burstY:  120, burstX:  80,  delay: 0.16 },
+    { char: '.', burstY: -40,  burstX:  60,  delay: 0.24 },
+];
+
+const enterVariant = (delay) => ({
+    hidden:  { opacity: 0, y: 50, scale: 0.85 },
+    visible: {
+        opacity: 1, y: 0, scale: 1,
+        transition: { delay, duration: 0.55, ease: [0.16, 1, 0.3, 1] },
+    },
+});
+
+const burstVariant = ({ burstY, burstX, delay }) => ({
+    opacity: 0,
+    scale: 3.5,
+    x: burstX,
+    y: burstY,
+    filter: 'blur(18px)',
+    transition: { delay, duration: 0.38, ease: [0.4, 0, 1, 1] },
+});
+
+const IntroSplash = ({ onDone }) => {
+    const [phase, setPhase] = useState('enter');
+
+    const done = useCallback(() => onDone?.(), [onDone]);
+
+    useEffect(() => {
+        const t1 = setTimeout(() => setPhase('burst'), 950);
+        const t2 = setTimeout(() => setPhase('fade'),  1260);
+        const t3 = setTimeout(done,                    1700);
+        return () => [t1, t2, t3].forEach(clearTimeout);
+    }, [done]);
+
+    return (
+        <AnimatePresence>
+            {phase !== 'done' && (
+                <Overlay
+                    key="splash"
+                    initial={{ opacity: 1 }}
+                    animate={{ opacity: phase === 'fade' ? 0 : 1 }}
+                    transition={{ duration: 0.44, ease: 'easeInOut' }}
+                >
+                    <Initials>
+                        {CHARS.map(({ char, burstY, burstX, delay }, i) => {
+                            const v = enterVariant(delay);
+                            return (
+                                <GradientChar
+                                    key={i}
+                                    variants={v}
+                                    initial="hidden"
+                                    animate={
+                                        phase === 'burst' || phase === 'fade'
+                                            ? burstVariant({ burstY, burstX, delay: delay * 0.5 })
+                                            : 'visible'
+                                    }
+                                    style={{ letterSpacing: char === '.' ? '-4px' : '-2px' }}
+                                >
+                                    {char}
+                                </GradientChar>
+                            );
+                        })}
+                    </Initials>
+                </Overlay>
+            )}
+        </AnimatePresence>
+    );
+};
+
+/* Gate: only show once per browser session */
+export const shouldShowSplash = () => {
+    if (typeof window === 'undefined') return false;
+    if (sessionStorage.getItem('intro_shown')) return false;
+    sessionStorage.setItem('intro_shown', '1');
+    return true;
+};
+
+export default IntroSplash;

--- a/src/components/Navbar/NavbarStyledComponent.js
+++ b/src/components/Navbar/NavbarStyledComponent.js
@@ -17,6 +17,33 @@ export const Nav = styled.div`
     box-shadow: ${({ scrolled }) => scrolled ? '0 4px 15px rgba(0, 0, 0, 0.1)' : 'none'};
 `;
 
+export const ProgressBar = styled.div`
+    position: fixed;
+    top: 80px;
+    left: 0;
+    height: 3px;
+    background: linear-gradient(90deg, #2F81F7, #0EA5E9);
+    width: ${({ progress }) => progress}%;
+    z-index: 10;
+    transition: width 0.1s linear;
+    border-radius: 0 2px 2px 0;
+`;
+
+export const InitialsBadge = styled.div`
+    width: 38px;
+    height: 38px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #2F81F7, #0EA5E9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.5px;
+    flex-shrink: 0;
+`;
+
 export const NavbarContainer = styled.div`
     display: flex;
     justify-content: space-between;

--- a/src/components/Navbar/NavbarStyledComponent.js
+++ b/src/components/Navbar/NavbarStyledComponent.js
@@ -24,9 +24,10 @@ export const ProgressBar = styled.div`
     height: 3px;
     background: linear-gradient(90deg, #2F81F7, #0EA5E9);
     width: ${({ progress }) => progress}%;
-    z-index: 10;
+    z-index: 1001;
     transition: width 0.1s linear;
     border-radius: 0 2px 2px 0;
+    pointer-events: none;
 `;
 
 export const InitialsBadge = styled.div`
@@ -236,12 +237,15 @@ export const MobileMenu = styled.div`
     padding: 32px 40px 64px;
     background: ${({ theme }) => `${theme.card_light}f5`};
     backdrop-filter: blur(10px);
-    transition: all 0.3s ease-in-out;
-    transform: ${({ isOpen }) => (isOpen ? 'translateY(0)' : 'translateY(-100vh)')};
     border-radius: 0 0 20px 20px;
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-    opacity: ${({ isOpen }) => (isOpen ? '100%' : '0')};
-    z-index: ${({ isOpen }) => (isOpen ? '1000' : '-1000')};
     max-height: 85vh;
     overflow-y: auto;
+    /* Animate via opacity + transform together so transition plays on both open and close */
+    transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+    opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+    transform: ${({ isOpen }) => (isOpen ? 'translateY(0)' : 'translateY(-20px)')};
+    /* Keep in DOM but out of pointer interaction when closed */
+    pointer-events: ${({ isOpen }) => (isOpen ? 'all' : 'none')};
+    z-index: 1000;
 `;

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -1,5 +1,3 @@
-// Update your Navbar component to include the Certificates link
-
 import React, { useState, useEffect } from 'react';
 import {
   Nav,
@@ -13,9 +11,10 @@ import {
   MobileIcon,
   MobileMenu,
   MobileLink,
-  ThemeToggleButton
+  ThemeToggleButton,
+  ProgressBar,
+  InitialsBadge
 } from './NavbarStyledComponent';
-import { DiCssdeck } from 'react-icons/di';
 import { FaBars, FaTimes, FaMoon, FaSun, FaGithub } from 'react-icons/fa';
 import { Bio } from '../../data/constants';
 import { useTheme } from 'styled-components';
@@ -23,16 +22,18 @@ import { useTheme } from 'styled-components';
 const Navbar = ({ darkMode, toggleDarkMode }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const [scrollProgress, setScrollProgress] = useState(0);
   const theme = useTheme();
 
   useEffect(() => {
     const handleScroll = () => {
       const offset = window.scrollY;
-      if (offset > 50) {
-        setScrolled(true);
-      } else {
-        setScrolled(false);
-      }
+      setScrolled(offset > 50);
+
+      // Calculate scroll progress
+      const docHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      const progress = docHeight > 0 ? (offset / docHeight) * 100 : 0;
+      setScrollProgress(progress);
     };
 
     window.addEventListener('scroll', handleScroll);
@@ -60,7 +61,9 @@ const Navbar = ({ darkMode, toggleDarkMode }) => {
   ];
 
   return (
-      <Nav scrolled={scrolled}>
+      <>
+        <ProgressBar progress={scrollProgress} />
+        <Nav scrolled={scrolled}>
         <NavbarContainer>
           <NavLogo to="/">
             <a style={{
@@ -68,9 +71,11 @@ const Navbar = ({ darkMode, toggleDarkMode }) => {
               alignItems: "center",
               color: theme.text_primary,
               cursor: 'pointer',
-              textDecoration: 'none'
+              textDecoration: 'none',
+              gap: '10px'
             }}>
-              <DiCssdeck size="3rem" /> <Span>Portfolio</Span>
+              <InitialsBadge>J.O.</InitialsBadge>
+              <Span>Portfolio</Span>
             </a>
           </NavLogo>
 
@@ -131,6 +136,7 @@ const Navbar = ({ darkMode, toggleDarkMode }) => {
           )}
         </NavbarContainer>
       </Nav>
+      </>
   );
 };
 

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -101,39 +101,38 @@ const Navbar = ({ darkMode, toggleDarkMode }) => {
             </GitHubButton>
           </ButtonContainer>
 
-          {isOpen && (
-              <MobileMenu isOpen={isOpen}>
-                {navItems.map((item) => (
-                    <MobileLink
-                        key={item.name}
-                        href={item.href}
-                        onClick={closeMenu}
-                    >
-                      {item.name}
-                    </MobileLink>
-                ))}
-                <GitHubButton
-                    style={{
-                      padding: '10px 16px',
-                      background: `${theme.primary}`,
-                      color: 'white',
-                      width: 'max-content',
-                      margin: '16px auto 0',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      gap: '8px'
-                    }}
-                    href={Bio.github}
-                    target="_blank"
-                    rel="noopener noreferrer"
+          {/* Always mounted so the CSS transform animation plays on open/close */}
+          <MobileMenu isOpen={isOpen}>
+            {navItems.map((item) => (
+                <MobileLink
+                    key={item.name}
+                    href={item.href}
                     onClick={closeMenu}
                 >
-                  <FaGithub />
-                  GitHub Profile
-                </GitHubButton>
-              </MobileMenu>
-          )}
+                  {item.name}
+                </MobileLink>
+            ))}
+            <GitHubButton
+                style={{
+                  padding: '10px 16px',
+                  background: `${theme.primary}`,
+                  color: 'white',
+                  width: 'max-content',
+                  margin: '16px auto 0',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '8px'
+                }}
+                href={Bio.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={closeMenu}
+            >
+              <FaGithub />
+              GitHub Profile
+            </GitHubButton>
+          </MobileMenu>
         </NavbarContainer>
       </Nav>
       </>

--- a/src/components/NoiseTexture.js
+++ b/src/components/NoiseTexture.js
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+
+const NoiseTexture = () => {
+    const ref = useRef(null);
+
+    useEffect(() => {
+        const canvas = ref.current;
+        if (!canvas) return;
+
+        const draw = () => {
+            const w = canvas.width = window.innerWidth;
+            const h = canvas.height = window.innerHeight;
+            const ctx = canvas.getContext('2d');
+            const img = ctx.createImageData(w, h);
+            const d = img.data;
+            for (let i = 0; i < d.length; i += 4) {
+                const v = (Math.random() * 255) | 0;
+                d[i] = d[i + 1] = d[i + 2] = v;
+                d[i + 3] = 18;
+            }
+            ctx.putImageData(img, 0, 0);
+        };
+
+        draw();
+        window.addEventListener('resize', draw);
+        return () => window.removeEventListener('resize', draw);
+    }, []);
+
+    return (
+        <canvas
+            ref={ref}
+            style={{
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                pointerEvents: 'none',
+                zIndex: 9995,
+                mixBlendMode: 'overlay',
+            }}
+        />
+    );
+};
+
+export default NoiseTexture;

--- a/src/components/ProjectDetails/index.jsx
+++ b/src/components/ProjectDetails/index.jsx
@@ -7,12 +7,12 @@ import {
     FaTimes,
     FaCalendarAlt,
     FaTag,
-    FaUsers
 } from 'react-icons/fa';
 import { Modal } from '@mui/material';
 import useGithubContributors from '../../hooks/useGithubContributors';
 
-// Styled Components
+/* ─── Backdrop ─── */
+
 const Container = styled(motion.div)`
     position: fixed;
     inset: 0;
@@ -20,46 +20,29 @@ const Container = styled(motion.div)`
     height: 100vh;
     padding: 24px;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     overflow-y: auto;
     z-index: 1000;
-    background: radial-gradient(1200px 600px at 10% -10%, rgba(2, 6, 23, 0.35), transparent),
-                radial-gradient(1200px 600px at 110% 110%, rgba(2, 6, 23, 0.35), transparent),
-                rgba(0, 0, 0, 0.45);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 `;
 
+/* ─── Modal shell ─── */
+
 const Wrapper = styled(motion.div)`
-    max-width: 880px;
+    max-width: 860px;
     width: 100%;
-    max-height: 90vh;
-    overflow-y: auto;
-    border-radius: 16px;
-    margin: 40px auto;
+    margin: 40px auto 60px;
     background: ${({ theme }) => theme.card};
-    color: ${({ theme }) => theme.text_primary};
-    padding: 28px 28px 96px;
-    display: flex;
-    flex-direction: column;
+    border-radius: 20px;
+    overflow: hidden;
     position: relative;
-    border: 1px solid rgba(148, 163, 184, 0.12);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(148, 163, 184, 0.1);
+    box-shadow: 0 32px 64px rgba(0, 0, 0, 0.45);
 
-    @media (max-width: 768px) {
-        padding: 18px 18px 22px;
-        margin: 20px auto;
-        max-height: calc(100vh - 60px);
-    }
-
-    /* Smooth scrolling feel inside the dialog */
-    scroll-behavior: smooth;
-
-    /* Optional: subtle inner scrollbar style that uses theme tokens */
-    &::-webkit-scrollbar {
-        width: 6px;
-    }
+    &::-webkit-scrollbar { width: 6px; }
     &::-webkit-scrollbar-thumb {
         background: ${({ theme }) => theme.scrollbar.thumb};
         border-radius: 6px;
@@ -67,269 +50,251 @@ const Wrapper = styled(motion.div)`
     &::-webkit-scrollbar-thumb:hover {
         background: ${({ theme }) => theme.scrollbar.thumbHover};
     }
+
+    @media (max-width: 768px) {
+        margin: 20px auto 40px;
+        border-radius: 16px;
+    }
+`;
+
+/* ─── Hero banner ─── */
+
+const HeroBanner = styled.div`
+    position: relative;
+    width: 100%;
+    height: 260px;
+    overflow: hidden;
+    flex-shrink: 0;
+
+    @media (max-width: 768px) {
+        height: 200px;
+    }
+`;
+
+const HeroImg = styled.img`
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+`;
+
+const HeroOverlay = styled.div`
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        to top,
+        rgba(0,0,0,0.85) 0%,
+        rgba(0,0,0,0.3) 55%,
+        rgba(0,0,0,0.1) 100%
+    );
+`;
+
+const HeroContent = styled.div`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+`;
+
+const HeroTitle = styled.h2`
+    font-size: 28px;
+    font-weight: 700;
+    color: #fff;
+    line-height: 1.25;
+    margin: 0;
+    text-shadow: 0 2px 8px rgba(0,0,0,0.4);
+
+    @media (max-width: 768px) {
+        font-size: 22px;
+    }
+`;
+
+const HeroMeta = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
 `;
 
 const CloseButton = styled.button`
     position: absolute;
-    top: 16px;
-    right: 16px;
-    background: ${({ theme }) => `${theme.white}12`};
-    color: ${({ theme }) => theme.text_primary};
-    border: 1px solid ${({ theme }) => `${theme.white}1F`};
-    width: 44px;
-    height: 44px;
+    top: 14px;
+    right: 14px;
+    background: rgba(0,0,0,0.45);
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.2);
+    width: 40px;
+    height: 40px;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out, border-color 0.2s ease-in-out;
-    z-index: 15;
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-    box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+    transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+    z-index: 10;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
 
     &:hover {
-        background: ${({ theme }) => `${theme.primary}26`};
-        color: ${({ theme }) => theme.white};
-        transform: scale(1.06);
-        border-color: ${({ theme }) => `${theme.primary}40`};
+        background: rgba(0,0,0,0.7);
+        transform: scale(1.08);
     }
 `;
 
-// New layout pieces
-const Header = styled.div`
-    position: sticky;
-    top: 0;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px 16px;
-    padding: 6px 0 12px;
-    padding-right: 72px; /* reserve space for close button */
-    margin-bottom: 16px;
-    background: ${({ theme }) => `${theme.card}CC`};
-    backdrop-filter: blur(6px);
-    -webkit-backdrop-filter: blur(6px);
-    border-bottom: 1px solid rgba(148, 163, 184, 0.12);
-    z-index: 3;
-    flex-wrap: wrap;
+/* ─── Status & category badges ─── */
+
+const StatusPill = styled.span`
+    font-size: 12px;
+    font-weight: 600;
+    padding: 4px 12px;
+    border-radius: 50px;
+    color: ${({ status }) => {
+        if (status === 'Deployed') return '#3dd391';
+        if (status === 'Work in progress') return '#f39c12';
+        return '#fff';
+    }};
+    background: ${({ status }) => {
+        if (status === 'Deployed') return 'rgba(61,211,145,0.2)';
+        if (status === 'Work in progress') return 'rgba(243,156,18,0.2)';
+        return 'rgba(255,255,255,0.15)';
+    }};
+    border: 1px solid ${({ status }) => {
+        if (status === 'Deployed') return 'rgba(61,211,145,0.4)';
+        if (status === 'Work in progress') return 'rgba(243,156,18,0.4)';
+        return 'rgba(255,255,255,0.25)';
+    }};
+    backdrop-filter: blur(4px);
 `;
 
-const Content = styled.div`
-    display: grid;
-    grid-template-columns: 1fr 320px;
-    gap: 24px;
-    padding-bottom: 140px; /* reserve space so sticky actions never overlap content */
+const CategoryPill = styled.span`
+    font-size: 12px;
+    font-weight: 600;
+    padding: 4px 12px;
+    border-radius: 50px;
+    color: rgba(255,255,255,0.9);
+    background: rgba(47,129,247,0.3);
+    border: 1px solid rgba(47,129,247,0.4);
+    backdrop-filter: blur(4px);
+    text-transform: capitalize;
+`;
 
-    @media (max-width: 900px) {
+/* ─── Body ─── */
+
+const Body = styled.div`
+    padding: 24px 28px 100px;
+
+    @media (max-width: 768px) {
+        padding: 20px 18px 80px;
+    }
+`;
+
+const BodyGrid = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 240px;
+    gap: 24px;
+
+    @media (max-width: 860px) {
         grid-template-columns: 1fr;
-        padding-bottom: 160px;
     }
 `;
 
 const Main = styled.div`
     display: flex;
     flex-direction: column;
+    gap: 0;
+    min-width: 0;
 `;
 
-const Aside = styled.aside`
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-`;
+/* ─── Tags ─── */
 
-const PreviewCard = styled.div`
-    background: ${({ theme }) => theme.card_light};
-    border: 1px solid rgba(148, 163, 184, 0.12);
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow: 0 10px 24px rgba(0,0,0,0.25);
-`;
-
-const PreviewImage = styled.img`
-    width: 100%;
-    display: block;
-    aspect-ratio: 16/9;
-    object-fit: cover;
-`;
-
-const MetaPanel = styled.div`
-    background: ${({ theme }) => theme.card_light};
-    border: 1px solid rgba(148, 163, 184, 0.12);
-    border-radius: 12px;
-    padding: 14px 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-`;
-
-const MetaRow = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    font-size: 14px;
-    color: ${({ theme }) => theme.text_secondary};
-`;
-
-const Title = styled.h2`
-    font-size: 32px;
-    font-weight: 700;
-    color: ${({ theme }) => theme.text_primary};
-    margin: 8px 0;
-
-    @media only screen and (max-width: 768px) {
-        font-size: 28px;
-        margin: 6px 0;
-    }
-`;
-
-const InfoContainer = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    margin: 16px 0;
-`;
-
-const InfoItem = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 16px;
-    color: ${({ theme }) => theme.text_secondary};
-`;
-
-const Date = styled(InfoItem)`
-    color: ${({ theme }) => theme.text_secondary};
-`;
-
-const Tags = styled.div`
+const TagRow = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    margin: 16px 0;
+    margin-bottom: 20px;
 `;
 
 const Tag = styled.span`
-    font-size: 14px;
-    font-weight: 500;
-    color: ${({ theme }) => theme.primary};
-    background-color: ${({ theme }) => `${theme.primary}20`};
-    padding: 6px 14px;
-    border-radius: 50px;
-    transition: background-color 0.2s ease-in-out;
-
-    &:hover {
-        background-color: ${({ theme }) => `${theme.primary}40`};
-    }
-`;
-
-const StatusBadge = styled.div`
-    font-size: 14px;
-    font-weight: 500;
-    color: ${({ theme, status }) => {
-        if (status === "Deployed") return "#3dd391";
-        if (status === "Work in progress") return "#f39c12";
-        return theme.primary;
-    }};
-    background-color: ${({ theme, status }) => {
-        if (status === "Deployed") return "rgba(61, 211, 145, 0.15)";
-        if (status === "Work in progress") return "rgba(243, 156, 18, 0.15)";
-        return `${theme.primary}20`;
-    }};
-    padding: 6px 14px;
-    border-radius: 50px;
-    display: inline-block;
-    margin-bottom: 16px;
-`;
-
-const Description = styled.div`
-    font-size: 16px;
-    font-weight: 400;
-    color: ${({ theme }) => theme.text_primary};
-    line-height: 1.7;
-    margin: 16px 0 24px;
-
-    @media only screen and (max-width: 768px) {
-        font-size: 15px;
-        margin: 12px 0 20px;
-    }
-`;
-
-const Label = styled.h3`
-    font-size: 20px;
+    font-size: 12px;
     font-weight: 600;
-    color: ${({ theme }) => theme.text_primary};
-    margin: 24px 0 12px;
-
-    @media only screen and (max-width: 768px) {
-        font-size: 18px;
-        margin: 20px 0 10px;
-    }
+    color: ${({ theme }) => theme.primary};
+    background: ${({ theme }) => `${theme.primary}18`};
+    border: 1px solid ${({ theme }) => `${theme.primary}30`};
+    padding: 4px 12px;
+    border-radius: 50px;
 `;
+
+/* ─── Description ─── */
+
+const Description = styled.p`
+    font-size: 15px;
+    line-height: 1.75;
+    color: ${({ theme }) => theme.text_primary + 'DD'};
+    margin: 0 0 28px;
+`;
+
+/* ─── Section label ─── */
+
+const SectionLabel = styled.h3`
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: ${({ theme }) => theme.text_secondary};
+    margin: 0 0 12px;
+`;
+
+/* ─── Team members ─── */
 
 const Members = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    margin: 16px 0 24px;
+    gap: 10px;
+    margin-bottom: 28px;
 `;
 
 const Member = styled.div`
     display: flex;
     align-items: center;
     gap: 12px;
-    background-color: ${({ theme }) => theme.card_light};
-    padding: 12px 16px;
-    border-radius: 10px;
+    background: ${({ theme }) => theme.card_light};
+    padding: 10px 14px;
+    border-radius: 12px;
     transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 
     &:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
+        transform: translateY(-2px);
+        box-shadow: 0 4px 10px rgba(0,0,0,0.1);
     }
 `;
 
-const MemberImage = styled.img`
-    width: 46px;
-    height: 46px;
-    object-fit: cover;
+const MemberAvatar = styled.img`
+    width: 40px;
+    height: 40px;
     border-radius: 50%;
-    border: 2px solid ${({ theme }) => theme.primary};
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-
-    @media only screen and (max-width: 768px) {
-        width: 40px;
-        height: 40px;
-    }
+    object-fit: cover;
+    border: 2px solid ${({ theme }) => `${theme.primary}60`};
 `;
 
-const MemberInfo = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-`;
-
-const MemberName = styled.div`
-    font-size: 16px;
+const MemberName = styled.span`
+    font-size: 14px;
     font-weight: 500;
     color: ${({ theme }) => theme.text_primary};
-
-    @media only screen and (max-width: 768px) {
-        font-size: 14px;
-    }
+    flex: 1;
 `;
 
 const MemberLinks = styled.div`
     display: flex;
     gap: 8px;
-    margin-left: auto;
 `;
 
 const MemberLink = styled.a`
     color: ${({ theme }) => theme.text_secondary};
-    font-size: 18px;
+    font-size: 16px;
     transition: color 0.2s ease-in-out, transform 0.2s ease-in-out;
 
     &:hover {
@@ -338,149 +303,189 @@ const MemberLink = styled.a`
     }
 `;
 
-// Contributors styles
-const Contributors = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    margin: 16px 0 24px;
-`;
+/* ─── Contributors ─── */
 
 const ContributorsGrid = styled.div`
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 8px;
+    margin-bottom: 28px;
 `;
 
 const Contributor = styled.a`
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 10px 12px;
+    gap: 8px;
+    padding: 8px 12px;
     border-radius: 10px;
     text-decoration: none;
     color: inherit;
     background: ${({ theme }) => theme.card_light};
-    border: 1px solid rgba(148, 163, 184, 0.12);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    border: 1px solid rgba(148, 163, 184, 0.1);
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
 
     &:hover {
         transform: translateY(-2px);
-        box-shadow: 0 6px 12px rgba(0,0,0,0.12);
-        border-color: ${({ theme }) => theme.primary};
+        box-shadow: 0 5px 12px rgba(0,0,0,0.12);
+        border-color: ${({ theme }) => `${theme.primary}40`};
     }
 `;
 
 const ContributorAvatar = styled.img`
-    width: 36px;
-    height: 36px;
+    width: 30px;
+    height: 30px;
     border-radius: 50%;
     object-fit: cover;
     flex-shrink: 0;
 `;
 
-const ContributorName = styled.div`
-    display: flex;
-    flex-direction: column;
-    font-size: 14px;
+const ContributorName = styled.span`
+    font-size: 12px;
+    color: ${({ theme }) => theme.text_secondary};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 `;
 
-const ButtonGroup = styled.div`
-    position: sticky;
-    bottom: 12px;
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-    width: fit-content;
-    margin-left: auto;
-    z-index: 5;
+/* ─── Aside / meta panel ─── */
 
-    @media only screen and (max-width: 768px) {
-        position: static;
-        width: 100%;
-        margin-top: 16px;
-        gap: 10px;
+const Aside = styled.aside`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+`;
+
+const MetaPanel = styled.div`
+    background: ${({ theme }) => theme.card_light};
+    border: 1px solid rgba(148, 163, 184, 0.1);
+    border-radius: 14px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+`;
+
+const MetaRow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 13px;
+`;
+
+const MetaLabel = styled.span`
+    color: ${({ theme }) => theme.text_secondary};
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+`;
+
+const MetaValue = styled.span`
+    color: ${({ theme }) => theme.text_primary};
+    font-weight: 600;
+    text-align: right;
+`;
+
+const MetaDivider = styled.div`
+    height: 1px;
+    background: ${({ theme }) => `${theme.text_primary}10`};
+`;
+
+/* ─── Buttons ─── */
+
+const ButtonGroup = styled.div`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 16px 28px;
+    display: flex;
+    gap: 12px;
+    background: ${({ theme }) => `${theme.card}F0`};
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-top: 1px solid rgba(148, 163, 184, 0.1);
+
+    @media (max-width: 768px) {
+        padding: 12px 18px;
         flex-direction: column;
     }
 `;
 
-const Button = styled.a`
+const Btn = styled.a`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 10px;
-    padding: 12px 18px;
-    height: 46px;
+    gap: 8px;
+    padding: 11px 24px;
     border-radius: 50px;
-    font-size: 15px;
+    font-size: 14px;
     font-weight: 600;
     cursor: pointer;
     text-decoration: none;
+    flex: 1;
     transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-    box-shadow: 0 8px 18px rgba(0,0,0,0.15);
 
-    @media only screen and (max-width: 768px) {
-        height: 44px;
-        padding: 10px 16px;
-        font-size: 14px;
+    @media (max-width: 768px) {
+        flex: unset;
         width: 100%;
     }
 `;
 
-const GithubButton = styled(Button)`
+const GithubButton = styled(Btn)`
     background: transparent;
     color: ${({ theme }) => theme.primary};
-    border: 1.5px solid ${({ theme }) => theme.primary};
+    border: 1.5px solid ${({ theme }) => `${theme.primary}60`};
 
     &:hover {
-        background: ${({ theme }) => theme.primary};
-        color: ${({ theme }) => theme.white};
+        background: ${({ theme }) => `${theme.primary}15`};
+        border-color: ${({ theme }) => theme.primary};
         transform: translateY(-2px);
-        box-shadow: 0 10px 20px ${({ theme }) => `${theme.primary}40`};
+        box-shadow: 0 6px 16px ${({ theme }) => `${theme.primary}25`};
     }
 `;
 
-const LiveButton = styled(Button)`
-    background: ${({ theme }) => theme.primary};
-    color: ${({ theme }) => theme.white};
-    border: 1.5px solid ${({ theme }) => `${theme.primary}CC`};
+const LiveButton = styled(Btn)`
+    background: linear-gradient(135deg, #2F81F7, #0EA5E9);
+    color: #fff;
+    border: none;
 
     &:hover {
-        background: ${({ theme }) => `${theme.primary}E6`};
         transform: translateY(-2px);
-        box-shadow: 0 12px 24px ${({ theme }) => `${theme.primary}40`};
+        box-shadow: 0 8px 20px rgba(47,129,247,0.4);
     }
 `;
+
+/* ─── Component ─── */
+
+const getLiveLabel = (category) => {
+    if (category === 'android app') return 'Google Play';
+    if (category === 'ios app') return 'App Store';
+    if (category === 'web app') return 'Live Demo';
+    return 'View Project';
+};
 
 const ProjectDetails = ({ openModal, setOpenModal }) => {
     const project = openModal?.project;
     const { contributors } = useGithubContributors(project?.github, { limit: 12 });
+    const imageSrc = project?.imageUrl || project?.image || '';
+    const categoryStr = Array.isArray(project?.category) ? project.category.join(', ') : project?.category;
 
-    // Close modal with ESC key
     useEffect(() => {
         const handleKeyDown = (e) => {
-            if (e.key === 'Escape') {
-                setOpenModal({ state: false, project: null });
-            }
+            if (e.key === 'Escape') setOpenModal({ state: false, project: null });
         };
-
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, [setOpenModal]);
 
-    // We will not manipulate body scroll in the component
-    // This prevents conflicts with MUI's own scroll handling
+    const close = () => setOpenModal({ state: false, project: null });
 
     return (
         <Modal
             open={true}
-            onClose={() => {
-                // Explicitly reset body overflow when modal closes
-                setTimeout(() => {
-                    document.body.style.overflow = '';
-                }, 0);
-                setOpenModal({ state: false, project: null });
-            }}
+            onClose={() => { setTimeout(() => { document.body.style.overflow = ''; }, 0); close(); }}
             aria-labelledby="project-details-modal"
             BackdropProps={{ timeout: 250 }}
             hideBackdrop
@@ -491,163 +496,139 @@ const ProjectDetails = ({ openModal, setOpenModal }) => {
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.25 }}
-                onClick={() => setOpenModal({ state: false, project: null })}
+                onClick={close}
             >
                 <Wrapper
-                    initial={{ opacity: 0, y: 40 }}
+                    initial={{ opacity: 0, y: 48 }}
                     animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 40 }}
+                    exit={{ opacity: 0, y: 48 }}
                     transition={{ duration: 0.3, ease: 'easeOut' }}
                     onClick={(e) => e.stopPropagation()}
                 >
-                    <CloseButton
-                        onClick={(e) => { e.stopPropagation(); setOpenModal({ state: false, project: null }); }}
-                        aria-label="Close modal"
-                    >
-                        <FaTimes />
-                    </CloseButton>
+                    {/* Hero banner */}
+                    <HeroBanner>
+                        {imageSrc && <HeroImg src={imageSrc} alt={project?.title} />}
+                        <HeroOverlay />
+                        <CloseButton onClick={(e) => { e.stopPropagation(); close(); }} aria-label="Close">
+                            <FaTimes size={16} />
+                        </CloseButton>
+                        <HeroContent>
+                            <HeroMeta>
+                                {project?.status && <StatusPill status={project.status}>{project.status}</StatusPill>}
+                                {categoryStr && <CategoryPill>{categoryStr}</CategoryPill>}
+                            </HeroMeta>
+                            <HeroTitle>{project?.title}</HeroTitle>
+                        </HeroContent>
+                    </HeroBanner>
 
-                    <Header>
-                        <Title>{project?.title}</Title>
-                        <InfoContainer>
-                            <Date>
-                                <FaCalendarAlt size={18} />
-                                {project?.date}
-                            </Date>
-                            <StatusBadge status={project?.status}>
-                                <FaTag size={14} style={{ marginRight: '6px' }} />
-                                {project?.status}
-                            </StatusBadge>
-                        </InfoContainer>
-                    </Header>
+                    {/* Body */}
+                    <Body>
+                        <BodyGrid>
+                            <Main>
+                                {project?.tags?.length > 0 && (
+                                    <TagRow>
+                                        {project.tags.map((tag, i) => <Tag key={i}>{tag}</Tag>)}
+                                    </TagRow>
+                                )}
 
-                    <Content>
-                        <Main>
-                            <Tags>
-                                {project?.tags.map((tag, index) => (
-                                    <Tag key={index}>{tag}</Tag>
-                                ))}
-                            </Tags>
+                                {project?.description && (
+                                    <Description>{project.description}</Description>
+                                )}
 
-                            <Description>{project?.description}</Description>
+                                {project?.member?.length > 0 && (
+                                    <>
+                                        <SectionLabel>Team Members</SectionLabel>
+                                        <Members>
+                                            {project.member.map((m, i) => (
+                                                <Member key={i}>
+                                                    <MemberAvatar src={m.img} alt={m.name} />
+                                                    <MemberName>{m.name}</MemberName>
+                                                    <MemberLinks>
+                                                        {m.github && (
+                                                            <MemberLink href={m.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                                                                <FaGithub />
+                                                            </MemberLink>
+                                                        )}
+                                                        {m.linkedin && (
+                                                            <MemberLink href={m.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+                                                                <FaExternalLinkAlt size={14} />
+                                                            </MemberLink>
+                                                        )}
+                                                    </MemberLinks>
+                                                </Member>
+                                            ))}
+                                        </Members>
+                                    </>
+                                )}
 
-                            {project?.member && (
-                                <>
-                                    <Label>Team Members</Label>
-                                    <Members>
-                                        {project?.member.map((member, index) => (
-                                            <Member key={index}>
-                                                <MemberImage src={member.img} alt={member.name} />
-                                                <MemberInfo>
-                                                    <MemberName>{member.name}</MemberName>
-                                                </MemberInfo>
-                                                <MemberLinks>
-                                                    <MemberLink
-                                                        href={member.github}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        aria-label="GitHub"
-                                                    >
-                                                        <FaGithub />
-                                                    </MemberLink>
-                                                    <MemberLink
-                                                        href={member.linkedin}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        aria-label="LinkedIn"
-                                                    >
-                                                        <FaExternalLinkAlt size={16} />
-                                                    </MemberLink>
-                                                </MemberLinks>
-                                            </Member>
-                                        ))}
-                                    </Members>
-                                </>
-                            )}
-
-                            {project?.github && contributors && contributors.length > 0 && (
-                                <>
-                                    <Label>Contributors</Label>
-                                    <Contributors>
+                                {contributors?.length > 0 && (
+                                    <>
+                                        <SectionLabel>Contributors</SectionLabel>
                                         <ContributorsGrid>
                                             {contributors.map((c) => (
-                                                <Contributor
-                                                    key={c.id || c.login}
-                                                    href={c.html_url}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    title={`@${c.login}`}
-                                                >
+                                                <Contributor key={c.id || c.login} href={c.html_url} target="_blank" rel="noopener noreferrer">
                                                     <ContributorAvatar src={c.avatar_url} alt={c.login} loading="lazy" />
                                                     <ContributorName>@{c.login}</ContributorName>
                                                 </Contributor>
                                             ))}
                                         </ContributorsGrid>
-                                    </Contributors>
-                                </>
-                            )}
-                        </Main>
-
-                        <Aside>
-                            {(() => {
-                                const previewSrc = project?.imageUrl || project?.image || '';
-                                return previewSrc ? (
-                                    <PreviewCard>
-                                        <PreviewImage src={previewSrc} alt={project?.title} loading="lazy" />
-                                    </PreviewCard>
-                                ) : null;
-                            })()}
-                            <MetaPanel>
-                                <MetaRow>
-                                    <span>Category</span>
-                                    <span style={{ color: 'inherit' }}>
-                                        {Array.isArray(project?.category) ? project?.category?.join(', ') : project?.category}
-                                    </span>
-                                </MetaRow>
-                                {project?.date && (
-                                    <MetaRow>
-                                        <span>Date</span>
-                                        <span style={{ color: 'inherit' }}>{project?.date}</span>
-                                    </MetaRow>
+                                    </>
                                 )}
-                                {project?.status && (
-                                    <MetaRow>
-                                        <span>Status</span>
-                                        <span style={{ color: 'inherit' }}>{project?.status}</span>
-                                    </MetaRow>
-                                )}
-                            </MetaPanel>
-                        </Aside>
-                    </Content>
+                            </Main>
 
+                            <Aside>
+                                <MetaPanel>
+                                    {project?.date && (
+                                        <>
+                                            <MetaRow>
+                                                <MetaLabel><FaCalendarAlt size={13} /> Date</MetaLabel>
+                                                <MetaValue>{project.date}</MetaValue>
+                                            </MetaRow>
+                                            <MetaDivider />
+                                        </>
+                                    )}
+                                    {categoryStr && (
+                                        <>
+                                            <MetaRow>
+                                                <MetaLabel><FaTag size={13} /> Type</MetaLabel>
+                                                <MetaValue style={{ textTransform: 'capitalize' }}>{categoryStr}</MetaValue>
+                                            </MetaRow>
+                                            <MetaDivider />
+                                        </>
+                                    )}
+                                    {project?.status && (
+                                        <MetaRow>
+                                            <MetaLabel>Status</MetaLabel>
+                                            <MetaValue>{project.status}</MetaValue>
+                                        </MetaRow>
+                                    )}
+                                </MetaPanel>
+                            </Aside>
+                        </BodyGrid>
+                    </Body>
+
+                    {/* Sticky action buttons */}
                     <ButtonGroup>
-                        <GithubButton href={project?.github} target="_blank" rel="noopener noreferrer">
-                            <FaGithub size={20} />
-                            View Code
-                        </GithubButton>
-
-                        <LiveButton
-                            href={project?.webapp}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{
-                                opacity: project?.webapp === "" ? 0.5 : 1,
-                                pointerEvents: project?.webapp === "" ? "none" : "all",
-                            }}
-                        >
-                            <FaExternalLinkAlt size={18} />
-                            {
-                                project?.webapp === ""
-                                    ? 'Project not available'
-                                    : project?.category === "android app"
-                                        ? 'Google Play'
-                                        : project?.category === "ios app"
-                                            ? 'App Store'
-                                            : project?.category === "web app"
-                                                ? 'Live Demo'
-                                                : 'View Project'
-                            }
-                        </LiveButton>
+                        {project?.github && (
+                            <GithubButton href={project.github} target="_blank" rel="noopener noreferrer">
+                                <FaGithub size={17} />
+                                View Code
+                            </GithubButton>
+                        )}
+                        {project?.webapp !== undefined && (
+                            <LiveButton
+                                href={project.webapp || '#'}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                style={{
+                                    opacity: !project.webapp ? 0.45 : 1,
+                                    pointerEvents: !project.webapp ? 'none' : 'all',
+                                }}
+                            >
+                                <FaExternalLinkAlt size={15} />
+                                {!project.webapp ? 'Not available' : getLiveLabel(project.category)}
+                            </LiveButton>
+                        )}
                     </ButtonGroup>
                 </Wrapper>
             </Container>

--- a/src/components/ProjectDetails/index.jsx
+++ b/src/components/ProjectDetails/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
 import {
     FaGithub,
     FaExternalLinkAlt,
@@ -11,29 +12,8 @@ import {
 import { Modal } from '@mui/material';
 import useGithubContributors from '../../hooks/useGithubContributors';
 
-// Animations
-const fadeIn = keyframes`
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-`;
-
-const slideUp = keyframes`
-    from {
-        transform: translateY(50px);
-        opacity: 0;
-    }
-    to {
-        transform: translateY(0);
-        opacity: 1;
-    }
-`;
-
 // Styled Components
-const Container = styled.div`
+const Container = styled(motion.div)`
     position: fixed;
     inset: 0;
     width: 100vw;
@@ -42,9 +22,8 @@ const Container = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    overflow-y: auto; /* Modal content scrolls when taller than viewport */
+    overflow-y: auto;
     z-index: 1000;
-    animation: ${fadeIn} 0.25s ease-in-out;
     background: radial-gradient(1200px 600px at 10% -10%, rgba(2, 6, 23, 0.35), transparent),
                 radial-gradient(1200px 600px at 110% 110%, rgba(2, 6, 23, 0.35), transparent),
                 rgba(0, 0, 0, 0.45);
@@ -52,22 +31,21 @@ const Container = styled.div`
     -webkit-backdrop-filter: blur(10px);
 `;
 
-const Wrapper = styled.div`
+const Wrapper = styled(motion.div)`
     max-width: 880px;
     width: 100%;
-    max-height: 90vh; /* Keep header/footer visible */
-    overflow-y: auto; /* Scroll inside the dialog */
+    max-height: 90vh;
+    overflow-y: auto;
     border-radius: 16px;
     margin: 40px auto;
     background: ${({ theme }) => theme.card};
     color: ${({ theme }) => theme.text_primary};
-    padding: 28px 28px 96px; /* extra bottom space for sticky actions */
+    padding: 28px 28px 96px;
     display: flex;
     flex-direction: column;
     position: relative;
     border: 1px solid rgba(148, 163, 184, 0.12);
     box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
-    animation: ${slideUp} 0.35s ease-in-out;
 
     @media (max-width: 768px) {
         padding: 18px 18px 22px;
@@ -105,7 +83,7 @@ const CloseButton = styled.button`
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    transition: all 0.2s ease-in-out;
+    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out, border-color 0.2s ease-in-out;
     z-index: 15;
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
@@ -239,8 +217,8 @@ const Tag = styled.span`
     color: ${({ theme }) => theme.primary};
     background-color: ${({ theme }) => `${theme.primary}20`};
     padding: 6px 14px;
-    border-radius: 8px;
-    transition: all 0.3s ease;
+    border-radius: 50px;
+    transition: background-color 0.2s ease-in-out;
 
     &:hover {
         background-color: ${({ theme }) => `${theme.primary}40`};
@@ -261,7 +239,7 @@ const StatusBadge = styled.div`
         return `${theme.primary}20`;
     }};
     padding: 6px 14px;
-    border-radius: 8px;
+    border-radius: 50px;
     display: inline-block;
     margin-bottom: 16px;
 `;
@@ -305,7 +283,7 @@ const Member = styled.div`
     background-color: ${({ theme }) => theme.card_light};
     padding: 12px 16px;
     border-radius: 10px;
-    transition: all 0.3s ease;
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 
     &:hover {
         transform: translateY(-3px);
@@ -352,7 +330,7 @@ const MemberLinks = styled.div`
 const MemberLink = styled.a`
     color: ${({ theme }) => theme.text_secondary};
     font-size: 18px;
-    transition: all 0.3s ease;
+    transition: color 0.2s ease-in-out, transform 0.2s ease-in-out;
 
     &:hover {
         color: ${({ theme }) => theme.primary};
@@ -433,12 +411,12 @@ const Button = styled.a`
     gap: 10px;
     padding: 12px 18px;
     height: 46px;
-    border-radius: 12px;
+    border-radius: 50px;
     font-size: 15px;
     font-weight: 600;
     cursor: pointer;
     text-decoration: none;
-    transition: all 0.2s ease;
+    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
     box-shadow: 0 8px 18px rgba(0,0,0,0.15);
 
     @media only screen and (max-width: 768px) {
@@ -508,8 +486,20 @@ const ProjectDetails = ({ openModal, setOpenModal }) => {
             hideBackdrop
             disableScrollLock={true}
         >
-            <Container onClick={() => setOpenModal({ state: false, project: null })}>
-                <Wrapper onClick={(e) => e.stopPropagation()}>
+            <Container
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.25 }}
+                onClick={() => setOpenModal({ state: false, project: null })}
+            >
+                <Wrapper
+                    initial={{ opacity: 0, y: 40 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 40 }}
+                    transition={{ duration: 0.3, ease: 'easeOut' }}
+                    onClick={(e) => e.stopPropagation()}
+                >
                     <CloseButton
                         onClick={(e) => { e.stopPropagation(); setOpenModal({ state: false, project: null }); }}
                         aria-label="Close modal"

--- a/src/components/Projects/ProjectsStyle.js
+++ b/src/components/Projects/ProjectsStyle.js
@@ -1,15 +1,4 @@
-import styled, { keyframes } from 'styled-components';
-
-const fadeIn = keyframes`
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-`;
+import styled from 'styled-components';
 
 export const Container = styled.div`
     background: linear-gradient(
@@ -37,7 +26,6 @@ export const Wrapper = styled.div`
     max-width: 1350px;
     padding: 10px 0px 100px 0;
     gap: 12px;
-    animation: ${fadeIn} 0.5s ease-in-out;
 
     @media (max-width: 960px) {
         padding: 0px 0px 80px 0;
@@ -136,5 +124,4 @@ export const EmptyProjectsMessage = styled.div`
     padding: 20px;
     border-radius: 12px;
     border: 1px dashed ${({ theme }) => theme.text_secondary};
-    animation: ${fadeIn} 0.5s ease-in-out;
 `;

--- a/src/components/Projects/ProjectsStyle.js
+++ b/src/components/Projects/ProjectsStyle.js
@@ -1,127 +1,128 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-    background: linear-gradient(
-            343.07deg,
-            ${({ theme }) => theme.gradients.projects.violetLight} 5.71%,
-            ${({ theme }) => theme.gradients.projects.violetZero} 64.83%
-    );
     display: flex;
     flex-direction: column;
     justify-content: center;
     position: relative;
     z-index: 1;
     align-items: center;
-    padding: 80px 0;
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 100% 98%, 0 100%);
+    padding: 80px 0 100px;
+    background: ${({ theme }) => theme.bg};
 `;
 
 export const Wrapper = styled.div`
     position: relative;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
     flex-direction: column;
+    align-items: center;
     width: 100%;
-    max-width: 1350px;
-    padding: 10px 0px 100px 0;
-    gap: 12px;
-
-    @media (max-width: 960px) {
-        padding: 0px 0px 80px 0;
-    }
-`;
-
-
-export const ToggleButtonGroup = styled.div`
-    display: flex;
-    border: 1.5px solid ${({ theme }) => theme.primary};
-    color: ${({ theme }) => theme.primary};
-    font-size: 16px;
-    border-radius: 12px;
-    font-weight: 500;
-    margin: 22px 0px 40px 0px;
-    overflow: hidden;
+    max-width: 1200px;
+    padding: 0 24px;
+    gap: 0;
 
     @media (max-width: 768px) {
-        font-size: 12px;
-        margin-bottom: 30px;
-        border-radius: 10px;
-    }
-
-    &.show-more {
-        margin: 40px auto 0;
-        width: auto;
-        border-radius: 20px;
+        padding: 0 16px;
     }
 `;
 
-export const ToggleButton = styled.div`
-    padding: 8px 18px;
-    cursor: pointer;
-    transition: all 0.3s ease-in-out;
-    text-align: center;
+/* ── Filter chips ── */
+
+export const FilterRow = styled.div`
     display: flex;
-    align-items: center;
-    
-    ${({ active, theme }) =>
-    active && `
-            background: ${theme.primary};
-            color: ${theme.white};
-        `
-}
-    
-    &:hover {
-        background: ${({ theme, active }) => active ? theme.primary : `${theme.primary}22`};
-        color: ${({ theme, active }) => active ? theme.white : theme.primary};
-    }
-    
-    @media (max-width: 768px) {
-        padding: 6px 12px;
-        border-radius: 4px;
-    }
-    
-    &.show-more {
-        background: transparent;
-        color: ${({ theme }) => theme.primary};
-        border: 1.5px solid ${({ theme }) => theme.primary};
-        border-radius: 20px;
-        padding: 10px 24px;
-        transition: all 0.3s ease-in-out;
-        margin: 0 auto;
-        
-        &:hover {
-            background: ${({ theme }) => theme.primary};
-            color: ${({ theme }) => theme.white};
-            transform: translateY(-3px);
-        }
-    }
-`;
-
-export const Divider = styled.div`
-    width: 1.5px;
-    background: ${({ theme }) => theme.primary};
-`;
-
-export const CardContainer = styled.div`
-    display: flex;
-    justify-content: center;
-    align-items: center;
     flex-wrap: wrap;
-    gap: 28px;
-    
-    @media (max-width: 768px) {
-        gap: 20px;
+    gap: 10px;
+    justify-content: center;
+    margin: 32px 0 40px;
+`;
+
+export const FilterChip = styled.button`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 20px;
+    border-radius: 50px;
+    font-size: 13px;
+    font-weight: 600;
+    font-family: inherit;
+    letter-spacing: 0.4px;
+    cursor: pointer;
+    border: 1.5px solid ${({ active, theme }) => active ? theme.primary : `${theme.text_primary}25`};
+    background: ${({ active, theme }) => active ? theme.primary : 'transparent'};
+    color: ${({ active, theme }) => active ? '#fff' : theme.text_secondary};
+    transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.2s, box-shadow 0.2s;
+
+    &:hover {
+        border-color: ${({ theme }) => theme.primary};
+        color: ${({ active, theme }) => active ? '#fff' : theme.primary};
+        transform: translateY(-2px);
+        box-shadow: ${({ active, theme }) => active
+            ? '0 6px 18px rgba(47,129,247,0.35)'
+            : '0 4px 12px rgba(47,129,247,0.12)'};
+    }
+
+    @media (max-width: 480px) {
+        padding: 7px 14px;
+        font-size: 12px;
     }
 `;
 
-export const EmptyProjectsMessage = styled.div`
+export const FilterCount = styled.span`
+    background: ${({ active, theme }) => active ? 'rgba(255,255,255,0.25)' : `${theme.primary}18`};
+    color: ${({ active, theme }) => active ? '#fff' : theme.primary};
+    border-radius: 50px;
+    padding: 0 7px;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.6;
+    min-width: 20px;
+    text-align: center;
+`;
+
+/* ── Cards grid ── */
+
+export const CardGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+    width: 100%;
+
+    @media (max-width: 720px) {
+        grid-template-columns: 1fr;
+        gap: 18px;
+    }
+`;
+
+export const EmptyMessage = styled.div`
+    grid-column: 1 / -1;
     text-align: center;
     color: ${({ theme }) => theme.text_secondary};
-    font-size: 18px;
-    margin: 50px 0;
-    max-width: 500px;
-    padding: 20px;
-    border-radius: 12px;
-    border: 1px dashed ${({ theme }) => theme.text_secondary};
+    font-size: 16px;
+    padding: 60px 20px;
+    border: 1.5px dashed ${({ theme }) => `${theme.text_primary}20`};
+    border-radius: 16px;
+    width: 100%;
+`;
+
+/* ── Show more ── */
+
+export const ShowMoreButton = styled.button`
+    margin-top: 40px;
+    padding: 12px 36px;
+    border-radius: 50px;
+    font-size: 14px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    border: 1.5px solid ${({ theme }) => theme.primary};
+    background: transparent;
+    color: ${({ theme }) => theme.primary};
+    transition: background 0.2s, color 0.2s, transform 0.2s, box-shadow 0.2s;
+
+    &:hover {
+        background: ${({ theme }) => theme.primary};
+        color: #fff;
+        transform: translateY(-2px);
+        box-shadow: 0 8px 20px rgba(47,129,247,0.3);
+    }
 `;

--- a/src/components/Projects/ProjectsStyle.js
+++ b/src/components/Projects/ProjectsStyle.js
@@ -44,34 +44,6 @@ export const Wrapper = styled.div`
     }
 `;
 
-export const Title = styled.h2`
-    font-size: 42px;
-    font-weight: 700;
-    text-align: center;
-    margin-top: 20px;
-    margin-bottom: 8px;
-    color: ${({ theme }) => theme.text_primary};
-
-    @media (max-width: 768px) {
-        margin-top: 12px;
-        font-size: 36px;
-    }
-`;
-
-export const Desc = styled.p`
-    font-size: 18px;
-    text-align: center;
-    max-width: 800px;
-    color: ${({ theme }) => theme.text_secondary};
-    line-height: 1.5;
-    margin-bottom: 40px;
-
-    @media (max-width: 768px) {
-        margin: 12px 0 30px;
-        font-size: 16px;
-        padding: 0 16px;
-    }
-`;
 
 export const ToggleButtonGroup = styled.div`
     display: flex;

--- a/src/components/Projects/index.js
+++ b/src/components/Projects/index.js
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from "react";
 import {
   Container,
   Wrapper,
-  Title,
-  Desc,
   CardContainer,
   ToggleButtonGroup,
   ToggleButton,
@@ -13,6 +11,7 @@ import {
 import ProjectCard from "../Cards/ProjectCards";
 import useContent from "../../hooks/useContent";
 import { motion, AnimatePresence } from "framer-motion";
+import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from "../SectionTitle";
 
 const Projects = ({ openModal, setOpenModal }) => {
   const [toggle, setToggle] = useState("all");
@@ -47,11 +46,22 @@ const Projects = ({ openModal, setOpenModal }) => {
   return (
       <Container id="projects">
         <Wrapper>
-          <Title>Projects</Title>
-          <Desc>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.2 }}
+            transition={{ duration: 0.5 }}
+            style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+          >
+          <SectionHeadingWrapper>
+            <SectionLabel>What I've Built</SectionLabel>
+            <SectionTitle>Projects</SectionTitle>
+          </SectionHeadingWrapper>
+          <SectionDesc>
             I've worked on a variety of projects ranging from web applications to mobile apps and APIs.
             Here's a showcase of my recent work and ongoing projects.
-          </Desc>
+          </SectionDesc>
+          </motion.div>
 
           <ToggleButtonGroup>
             {categories.map((category) => (

--- a/src/components/Projects/index.js
+++ b/src/components/Projects/index.js
@@ -2,123 +2,139 @@ import React, { useState, useEffect } from "react";
 import {
   Container,
   Wrapper,
-  CardContainer,
-  ToggleButtonGroup,
-  ToggleButton,
-  Divider,
-  EmptyProjectsMessage
+  FilterRow,
+  FilterChip,
+  FilterCount,
+  CardGrid,
+  EmptyMessage,
+  ShowMoreButton,
 } from "./ProjectsStyle";
 import ProjectCard from "../Cards/ProjectCards";
 import useContent from "../../hooks/useContent";
 import { motion, AnimatePresence } from "framer-motion";
 import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from "../SectionTitle";
 
+const LABEL_MAP = {
+  all: "All",
+  "web app": "Web Apps",
+  "android app": "Android",
+  api: "APIs",
+};
+
+const humanLabel = (cat) => LABEL_MAP[cat] || (cat ? cat.charAt(0).toUpperCase() + cat.slice(1) : cat);
+
 const Projects = ({ openModal, setOpenModal }) => {
-  const [toggle, setToggle] = useState("all");
-  const { data: projectsData, loading } = useContent('projects');
-  const [filteredProjects, setFilteredProjects] = useState([]);
-  const [visibleProjects, setVisibleProjects] = useState([]);
+  const [active, setActive] = useState("all");
+  const { data: projectsData, loading } = useContent("projects");
+  const [filtered, setFiltered] = useState([]);
+  const [visible, setVisible] = useState([]);
   const [showMore, setShowMore] = useState(false);
-  const projectsPerPage = 6;
+  const PER_PAGE = 6;
 
-  // Filter projects based on selected category
+  // Derive categories + per-category counts
+  const allProjects = projectsData || [];
+  const categories = [
+    "all",
+    ...new Set(
+      allProjects
+        .flatMap((p) => (Array.isArray(p.category) ? p.category : [p.category]))
+        .filter(Boolean)
+    ),
+  ];
+
+  const countFor = (cat) =>
+    cat === "all"
+      ? allProjects.length
+      : allProjects.filter((p) =>
+          (Array.isArray(p.category) ? p.category : [p.category]).includes(cat)
+        ).length;
+
   useEffect(() => {
-    const src = projectsData || [];
-    if (toggle === "all") {
-      setFilteredProjects(src);
+    if (active === "all") {
+      setFiltered(allProjects);
     } else {
-      setFilteredProjects(src.filter(item => (Array.isArray(item.category) ? item.category : [item.category]).includes(toggle)));
+      setFiltered(
+        allProjects.filter((p) =>
+          (Array.isArray(p.category) ? p.category : [p.category]).includes(active)
+        )
+      );
     }
-  }, [toggle, projectsData]);
+    setShowMore(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, projectsData]);
 
-  // Handle pagination
   useEffect(() => {
-    if (showMore) {
-      setVisibleProjects(filteredProjects);
-    } else {
-      setVisibleProjects(filteredProjects.slice(0, projectsPerPage));
-    }
-  }, [filteredProjects, showMore]);
-
-  // Get unique categories for filter buttons
-  const categories = ["all", ...new Set((projectsData || []).flatMap(project => Array.isArray(project.category) ? project.category : [project.category]).filter(Boolean))];
+    setVisible(showMore ? filtered : filtered.slice(0, PER_PAGE));
+  }, [filtered, showMore]);
 
   return (
-      <Container id="projects">
-        <Wrapper>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.2 }}
-            transition={{ duration: 0.5 }}
-            style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
-          >
+    <Container id="projects">
+      <Wrapper>
+        {/* Heading */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.5 }}
+          style={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%" }}
+        >
           <SectionHeadingWrapper>
             <SectionLabel>What I've Built</SectionLabel>
             <SectionTitle>Projects</SectionTitle>
           </SectionHeadingWrapper>
           <SectionDesc>
-            I've worked on a variety of projects ranging from web applications to mobile apps and APIs.
-            Here's a showcase of my recent work and ongoing projects.
+            A selection of projects I've built — from mobile apps to web platforms and APIs.
           </SectionDesc>
-          </motion.div>
+        </motion.div>
 
-          <ToggleButtonGroup>
-            {categories.map((category) => (
-                <React.Fragment key={category}>
-                  {category !== categories[0] && <Divider />}
-                  <ToggleButton
-                      active={toggle === category}
-                      onClick={() => setToggle(category)}
-                  >
-                    {category === "all" ? "ALL" :
-                        category === "web app" ? "WEB APPS" :
-                            category === "android app" ? "ANDROID APPS" :
-                                category === "api" ? "APIs" :
-                                    category.toUpperCase()}
-                  </ToggleButton>
-                </React.Fragment>
-            ))}
-          </ToggleButtonGroup>
+        {/* Filter chips */}
+        <FilterRow>
+          {categories.map((cat) => (
+            <FilterChip
+              key={cat}
+              active={active === cat}
+              onClick={() => setActive(cat)}
+            >
+              {humanLabel(cat)}
+              <FilterCount active={active === cat}>{countFor(cat)}</FilterCount>
+            </FilterChip>
+          ))}
+        </FilterRow>
 
-          <CardContainer>
-            <AnimatePresence>
-              {loading ? null : visibleProjects.length > 0 ? (
-                  visibleProjects.map((project, index) => (
-                      <motion.div
-                          key={project.id}
-                          initial={{ opacity: 0, y: 20 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          exit={{ opacity: 0, y: 20 }}
-                          transition={{ duration: 0.3, delay: index * 0.1 }}
-                      >
-                        <ProjectCard
-                            project={project}
-                            openModal={openModal}
-                            setOpenModal={setOpenModal}
-                            index={index}
-                        />
-                      </motion.div>
-                  ))
-              ) : (
-                  <EmptyProjectsMessage>
-                    No projects found in this category. Check back soon!
-                  </EmptyProjectsMessage>
-              )}
-            </AnimatePresence>
-          </CardContainer>
+        {/* Cards */}
+        <CardGrid>
+          <AnimatePresence mode="popLayout">
+            {loading ? null : visible.length > 0 ? (
+              visible.map((project, index) => (
+                <motion.div
+                  key={project.id ?? project.title}
+                  layout
+                  initial={{ opacity: 0, scale: 0.96 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.94 }}
+                  transition={{ duration: 0.25, delay: index * 0.05 }}
+                >
+                  <ProjectCard
+                    project={project}
+                    openModal={openModal}
+                    setOpenModal={setOpenModal}
+                  />
+                </motion.div>
+              ))
+            ) : (
+              <EmptyMessage>No projects in this category yet — check back soon!</EmptyMessage>
+            )}
+          </AnimatePresence>
+        </CardGrid>
 
-          {filteredProjects.length > projectsPerPage && (
-              <ToggleButton
-                  className="show-more"
-                  onClick={() => setShowMore(!showMore)}
-                  style={{ marginTop: '40px' }}
-              >
-                {showMore ? "Show Less" : "Show More"}
-              </ToggleButton>
-          )}
-        </Wrapper>
-      </Container>
+        {/* Show more */}
+        {filtered.length > PER_PAGE && (
+          <ShowMoreButton onClick={() => setShowMore((s) => !s)}>
+            {showMore ? "Show less" : `Show ${filtered.length - PER_PAGE} more`}
+          </ShowMoreButton>
+        )}
+      </Wrapper>
+    </Container>
   );
 };
 

--- a/src/components/SectionDivider.js
+++ b/src/components/SectionDivider.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+
+const Wrap = styled.div`
+  width: 100%;
+  overflow: hidden;
+  line-height: 0;
+  background: ${({ $bg }) => $bg};
+  position: relative;
+  z-index: 2;
+`;
+
+const SectionDivider = ({ from, to, flip = false }) => {
+  const theme = useTheme();
+  const fromColor = theme[from] || from;
+  const toColor = theme[to] || to;
+
+  return (
+    <Wrap $bg={fromColor}>
+      <svg
+        viewBox="0 0 1440 60"
+        xmlns="http://www.w3.org/2000/svg"
+        preserveAspectRatio="none"
+        style={{
+          display: 'block',
+          width: '100%',
+          height: '60px',
+          transform: flip ? 'scaleX(-1)' : 'none',
+        }}
+      >
+        <path d="M0,40 C360,80 1080,0 1440,40 L1440,60 L0,60 Z" fill={toColor} />
+      </svg>
+    </Wrap>
+  );
+};
+
+export default SectionDivider;

--- a/src/components/SectionTitle.js
+++ b/src/components/SectionTitle.js
@@ -1,15 +1,8 @@
-import styled, { keyframes } from "styled-components";
+import styled from "styled-components";
 
-const fadeIn = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
+// No CSS keyframe animations here — all sections use Framer Motion
+// whileInView on the parent motion.div wrapper, so CSS animations on children
+// would double-animate and cause jitter.
 
 export const SectionLabel = styled.div`
   display: inline-block;
@@ -23,7 +16,6 @@ export const SectionLabel = styled.div`
   border-radius: 50px;
   margin-bottom: 14px;
   border: 1px solid ${({ theme }) => `${theme.primary}30`};
-  animation: ${fadeIn} 0.5s ease-in-out;
 `;
 
 export const SectionTitle = styled.h2`
@@ -33,8 +25,9 @@ export const SectionTitle = styled.h2`
   margin-top: 4px;
   color: ${({ theme }) => theme.text_primary};
   position: relative;
-  display: inline-block;
-  animation: ${fadeIn} 0.5s ease-in-out;
+  /* block + text-align: center is correct for centering; inline-block caused misalignment */
+  display: block;
+  width: 100%;
 
   &:after {
     content: '';
@@ -61,8 +54,6 @@ export const SectionDesc = styled.p`
   line-height: 1.6;
   margin-top: 24px;
   margin-bottom: 40px;
-  animation: ${fadeIn} 0.5s ease-in-out 0.2s;
-  animation-fill-mode: both;
 
   @media (max-width: 768px) {
     font-size: 16px;
@@ -76,4 +67,5 @@ export const SectionHeadingWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   margin-bottom: 8px;
+  width: 100%;
 `;

--- a/src/components/SectionTitle.js
+++ b/src/components/SectionTitle.js
@@ -1,0 +1,79 @@
+import styled, { keyframes } from "styled-components";
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+export const SectionLabel = styled.div`
+  display: inline-block;
+  background: ${({ theme }) => `${theme.primary}18`};
+  color: ${({ theme }) => theme.primary};
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  padding: 6px 16px;
+  border-radius: 50px;
+  margin-bottom: 14px;
+  border: 1px solid ${({ theme }) => `${theme.primary}30`};
+  animation: ${fadeIn} 0.5s ease-in-out;
+`;
+
+export const SectionTitle = styled.h2`
+  font-size: 42px;
+  text-align: center;
+  font-weight: 700;
+  margin-top: 4px;
+  color: ${({ theme }) => theme.text_primary};
+  position: relative;
+  display: inline-block;
+  animation: ${fadeIn} 0.5s ease-in-out;
+
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 80px;
+    height: 3px;
+    background: linear-gradient(90deg, ${({ theme }) => theme.primary}, transparent);
+    border-radius: 10px;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 32px;
+  }
+`;
+
+export const SectionDesc = styled.p`
+  font-size: 18px;
+  text-align: center;
+  max-width: 600px;
+  color: ${({ theme }) => theme.text_secondary};
+  line-height: 1.6;
+  margin-top: 24px;
+  margin-bottom: 40px;
+  animation: ${fadeIn} 0.5s ease-in-out 0.2s;
+  animation-fill-mode: both;
+
+  @media (max-width: 768px) {
+    font-size: 16px;
+    margin-bottom: 30px;
+    padding: 0 16px;
+  }
+`;
+
+export const SectionHeadingWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 8px;
+`;

--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -13,6 +13,7 @@ const Container = styled.div`
   z-index: 1;
   align-items: center;
   padding: 80px 0;
+  background: ${({ theme }) => theme.bg};
 `;
 
 const Wrapper = styled.div`

--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -1,18 +1,9 @@
 import React, { useState } from "react";
-import styled, { keyframes } from "styled-components";
+import styled from "styled-components";
 import { skills } from "../../data/constants";
-import { motion } from "framer-motion";
-
-const fadeIn = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
+import { motion, AnimatePresence } from "framer-motion";
+import { SectionLabel, SectionTitle, SectionDesc, SectionHeadingWrapper } from "../SectionTitle";
+import { FaCode, FaServer, FaMobileAlt, FaTools } from "react-icons/fa";
 
 const Container = styled.div`
   display: flex;
@@ -34,210 +25,160 @@ const Wrapper = styled.div`
   max-width: 1100px;
   gap: 12px;
   padding: 0 20px;
-
-  @media (max-width: 960px) {
-    flex-direction: column;
-  }
 `;
 
-export const Title = styled.h2`
-  font-size: 42px;
-  text-align: center;
-  font-weight: 700;
-  margin-top: 20px;
-  color: ${({ theme }) => theme.text_primary};
-  animation: ${fadeIn} 0.5s ease-in-out;
-
-  @media (max-width: 768px) {
-    margin-top: 12px;
-    font-size: 36px;
-  }
-`;
-
-export const Desc = styled.p`
-  font-size: 18px;
-  text-align: center;
-  max-width: 600px;
-  color: ${({ theme }) => theme.text_secondary};
-  line-height: 1.5;
-  margin-bottom: 40px;
-  animation: ${fadeIn} 0.5s ease-in-out 0.2s;
-  animation-fill-mode: both;
-
-  @media (max-width: 768px) {
-    font-size: 16px;
-    margin-bottom: 30px;
-  }
-`;
-
-const SkillsContainer = styled.div`
-  width: 100%;
+const TabsRow = styled.div`
   display: flex;
+  gap: 0;
+  border: 1.5px solid ${({ theme }) => `${theme.primary}40`};
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 36px;
   flex-wrap: wrap;
-  gap: 30px;
-  justify-content: center;
 `;
 
-const Skill = styled(motion.div)`
-  width: 100%;
-  max-width: 500px;
-  background: ${({ theme }) => theme.card};
-  border: 1px solid ${({ theme }) => `${theme.primary}30`};
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-  border-radius: 16px;
-  padding: 24px 36px;
-  transition: all 0.3s ease-in-out;
+const Tab = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  cursor: pointer;
+  border: none;
+  background: ${({ active, theme }) => active ? theme.primary : 'transparent'};
+  color: ${({ active, theme }) => active ? theme.white : theme.text_secondary};
+  font-size: 15px;
+  font-weight: 600;
+  font-family: inherit;
+  transition: all 0.25s ease-in-out;
+  border-right: 1px solid ${({ theme }) => `${theme.primary}30`};
+
+  &:last-child {
+    border-right: none;
+  }
 
   &:hover {
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-    transform: translateY(-5px);
-    border: 1px solid ${({ theme }) => theme.primary};
+    background: ${({ active, theme }) => active ? theme.primary : `${theme.primary}18`};
+    color: ${({ active, theme }) => active ? theme.white : theme.primary};
   }
 
-  @media (max-width: 768px) {
-    max-width: 400px;
-    padding: 18px 24px;
-  }
-
-  @media (max-width: 500px) {
-    max-width: 330px;
-    padding: 16px 20px;
+  @media (max-width: 600px) {
+    padding: 10px 16px;
+    font-size: 13px;
+    gap: 6px;
   }
 `;
 
-const SkillTitle = styled.h3`
-  font-size: 28px;
-  font-weight: 600;
-  color: ${({ theme }) => theme.text_primary};
-  margin-bottom: 24px;
-  text-align: center;
-  position: relative;
-
-  &:after {
-    content: '';
-    position: absolute;
-    bottom: -10px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 60px;
-    height: 3px;
-    background: ${({ theme }) => theme.primary};
-    border-radius: 10px;
-  }
-
-  @media (max-width: 768px) {
-    font-size: 24px;
-  }
-`;
-
-const SkillList = styled.div`
+const SkillsGrid = styled(motion.div)`
+  width: 100%;
   display: flex;
-  justify-content: center;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 20px;
+  justify-content: center;
 `;
 
-const SkillItem = styled.div`
-  font-size: 16px;
-  font-weight: 400;
+const SkillItem = styled(motion.div)`
+  font-size: 15px;
+  font-weight: 500;
   color: ${({ theme }) => theme.text_primary + 'cc'};
-  border: 1px solid ${({ theme }) => theme.text_primary + '60'};
+  background: ${({ theme }) => theme.card};
+  border: 1px solid ${({ theme }) => theme.text_primary + '25'};
   border-radius: 12px;
-  padding: 12px 16px;
+  padding: 12px 18px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  transition: all 0.3s ease-in-out;
+  gap: 10px;
+  transition: all 0.25s ease-in-out;
+  cursor: default;
 
   &:hover {
     border: 1px solid ${({ theme }) => theme.primary};
     color: ${({ theme }) => theme.primary};
+    background: ${({ theme }) => `${theme.primary}10`};
     transform: translateY(-3px);
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 6px 16px rgba(47, 129, 247, 0.15);
   }
 
   @media (max-width: 768px) {
-    font-size: 14px;
+    font-size: 13px;
     padding: 10px 14px;
-  }
-
-  @media (max-width: 500px) {
-    font-size: 14px;
-    padding: 8px 12px;
   }
 `;
 
 const SkillImage = styled.img`
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   object-fit: contain;
-  
-  @media (max-width: 768px) {
-    width: 20px;
-    height: 20px;
-  }
 `;
 
-// Animation variants for staggered animation
-const containerVariants = {
+const CATEGORY_ICONS = {
+  "Frontend": <FaCode size={16} />,
+  "Backend": <FaServer size={16} />,
+  "Android": <FaMobileAlt size={16} />,
+  "Others": <FaTools size={16} />,
+};
+
+const gridVariants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
-    transition: {
-      staggerChildren: 0.2
-    }
-  }
+    transition: { staggerChildren: 0.05 }
+  },
+  exit: { opacity: 0, transition: { duration: 0.15 } }
 };
 
 const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.5
-    }
-  }
+  hidden: { opacity: 0, scale: 0.9 },
+  visible: { opacity: 1, scale: 1, transition: { duration: 0.2 } }
 };
 
 const Skills = () => {
-  return (
-      <Container id="skills">
-        <Wrapper>
-          <Title>Skills</Title>
-          <Desc>
-            Here are the technologies and tools I've been working with over the past few years.
-            I'm always excited to learn and adapt to new technologies.
-          </Desc>
+  const [activeTab, setActiveTab] = useState(0);
+  const currentSkill = skills[activeTab];
 
-          <SkillsContainer
-              as={motion.div}
-              variants={containerVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
+  return (
+    <Container id="skills">
+      <Wrapper>
+        <SectionHeadingWrapper>
+          <SectionLabel>What I Know</SectionLabel>
+          <SectionTitle>Skills</SectionTitle>
+        </SectionHeadingWrapper>
+        <SectionDesc>
+          Here are the technologies and tools I've been working with over the past few years.
+          I'm always excited to learn and adapt to new technologies.
+        </SectionDesc>
+
+        <TabsRow>
+          {skills.map((skill, index) => (
+            <Tab
+              key={index}
+              active={activeTab === index}
+              onClick={() => setActiveTab(index)}
+            >
+              {CATEGORY_ICONS[skill.title] || <FaCode size={16} />}
+              {skill.title}
+            </Tab>
+          ))}
+        </TabsRow>
+
+        <AnimatePresence mode="wait">
+          <SkillsGrid
+            key={activeTab}
+            variants={gridVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
           >
-            {skills.map((skill, index) => (
-                <Skill
-                    key={index}
-                    variants={itemVariants}
-                >
-                  <SkillTitle>{skill.title}</SkillTitle>
-                  <SkillList>
-                    {skill.skills.map((item, itemIndex) => (
-                        <SkillItem key={itemIndex}>
-                          <SkillImage src={item.image} alt={item.name} />
-                          {item.name}
-                        </SkillItem>
-                    ))}
-                  </SkillList>
-                </Skill>
+            {currentSkill?.skills.map((item, idx) => (
+              <SkillItem key={idx} variants={itemVariants}>
+                <SkillImage src={item.image} alt={item.name} />
+                {item.name}
+              </SkillItem>
             ))}
-          </SkillsContainer>
-        </Wrapper>
-      </Container>
+          </SkillsGrid>
+        </AnimatePresence>
+      </Wrapper>
+    </Container>
   );
 };
 

--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -32,9 +32,17 @@ const TabsRow = styled.div`
   gap: 0;
   border: 1.5px solid ${({ theme }) => `${theme.primary}40`};
   border-radius: 12px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   margin-bottom: 36px;
-  flex-wrap: wrap;
+  flex-shrink: 0;
+  max-width: 100%;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Tab = styled.button`
@@ -44,12 +52,14 @@ const Tab = styled.button`
   padding: 12px 24px;
   cursor: pointer;
   border: none;
+  flex-shrink: 0;
+  white-space: nowrap;
   background: ${({ active, theme }) => active ? theme.primary : 'transparent'};
   color: ${({ active, theme }) => active ? theme.white : theme.text_secondary};
   font-size: 15px;
   font-weight: 600;
   font-family: inherit;
-  transition: all 0.25s ease-in-out;
+  transition: background 0.25s ease-in-out, color 0.25s ease-in-out;
   border-right: 1px solid ${({ theme }) => `${theme.primary}30`};
 
   &:last-child {

--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -98,11 +98,11 @@ const SkillItem = styled(motion.div)`
   align-items: center;
   justify-content: center;
   gap: 10px;
-  transition: all 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out, border-color 0.25s ease-in-out, transform 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
   cursor: default;
 
   &:hover {
-    border: 1px solid ${({ theme }) => theme.primary};
+    border-color: ${({ theme }) => theme.primary};
     color: ${({ theme }) => theme.primary};
     background: ${({ theme }) => `${theme.primary}10`};
     transform: translateY(-3px);
@@ -149,14 +149,22 @@ const Skills = () => {
   return (
     <Container id="skills">
       <Wrapper>
-        <SectionHeadingWrapper>
-          <SectionLabel>What I Know</SectionLabel>
-          <SectionTitle>Skills</SectionTitle>
-        </SectionHeadingWrapper>
-        <SectionDesc>
-          Here are the technologies and tools I've been working with over the past few years.
-          I'm always excited to learn and adapt to new technologies.
-        </SectionDesc>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.5 }}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
+        >
+          <SectionHeadingWrapper>
+            <SectionLabel>What I Know</SectionLabel>
+            <SectionTitle>Skills</SectionTitle>
+          </SectionHeadingWrapper>
+          <SectionDesc>
+            Here are the technologies and tools I've been working with over the past few years.
+            I'm always excited to learn and adapt to new technologies.
+          </SectionDesc>
+        </motion.div>
 
         <TabsRow>
           {skills.map((skill, index) => (

--- a/src/components/Terminal/index.js
+++ b/src/components/Terminal/index.js
@@ -1,0 +1,396 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import styled, { keyframes } from 'styled-components';
+import { Bio } from '../../data/constants';
+
+const blink = keyframes`
+    0%, 49% { opacity: 1; }
+    50%, 100% { opacity: 0; }
+`;
+
+const Overlay = styled.div`
+    position: fixed;
+    inset: 0;
+    z-index: 99998;
+    background: rgba(0, 0, 0, 0.88);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    backdrop-filter: blur(6px);
+`;
+
+const Window = styled.div`
+    width: min(880px, 94vw);
+    height: min(580px, 86vh);
+    background: #0d120d;
+    border-radius: 12px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    box-shadow:
+        0 0 0 1px rgba(0, 255, 65, 0.12),
+        0 30px 90px rgba(0, 0, 0, 0.85),
+        0 0 80px rgba(0, 255, 65, 0.04);
+    position: relative;
+
+    /* CRT scanlines */
+    &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+            0deg,
+            transparent,
+            transparent 2px,
+            rgba(0, 0, 0, 0.06) 2px,
+            rgba(0, 0, 0, 0.06) 4px
+        );
+        pointer-events: none;
+        z-index: 10;
+        border-radius: 12px;
+    }
+`;
+
+const TitleBar = styled.div`
+    height: 38px;
+    background: #0a0f0a;
+    display: flex;
+    align-items: center;
+    padding: 0 14px;
+    gap: 8px;
+    border-bottom: 1px solid rgba(0, 255, 65, 0.08);
+    flex-shrink: 0;
+`;
+
+const TrafficDot = styled.button`
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: ${({ $color }) => $color};
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    opacity: 0.85;
+    transition: opacity 0.15s ease;
+    &:hover { opacity: 1; }
+`;
+
+const TitleText = styled.div`
+    flex: 1;
+    text-align: center;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: rgba(0, 255, 65, 0.35);
+    letter-spacing: 0.5px;
+    user-select: none;
+`;
+
+const Body = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 20px 8px;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 13px;
+    line-height: 1.65;
+
+    &::-webkit-scrollbar { width: 4px; }
+    &::-webkit-scrollbar-track { background: transparent; }
+    &::-webkit-scrollbar-thumb {
+        background: rgba(0, 255, 65, 0.15);
+        border-radius: 2px;
+    }
+`;
+
+const Line = styled.div`
+    color: ${({ $color }) => $color || '#00ff41'};
+    white-space: pre-wrap;
+    word-break: break-word;
+`;
+
+const InputRow = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 2px 0;
+    color: #00ff41;
+`;
+
+const Prompt = styled.span`
+    white-space: nowrap;
+    flex-shrink: 0;
+    user-select: none;
+`;
+
+const TermInput = styled.input`
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: #00ff41;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    caret-color: transparent;
+
+    &::selection { background: rgba(0, 255, 65, 0.2); }
+`;
+
+const Cursor = styled.span`
+    display: inline-block;
+    width: 7px;
+    height: 14px;
+    background: #00ff41;
+    animation: ${blink} 1.1s step-end infinite;
+    vertical-align: text-bottom;
+    flex-shrink: 0;
+`;
+
+/* ─── Data ─── */
+
+const PROMPT_STR = 'jakub@portfolio:~$ ';
+
+const BOOT = [
+    { text: 'Initialising secure connection...', color: '#4a4a4a' },
+    { text: 'Verifying credentials...', color: '#4a4a4a' },
+    { text: '✓ Access granted.', color: '#00ff41' },
+    { text: '' },
+    { text: '  jakub@portfolio — Interactive Terminal v1.0', color: '#00ff41' },
+    { text: "  Type 'help' for available commands.", color: '#555' },
+    { text: '' },
+];
+
+const HELP = [
+    { text: 'Commands:', color: '#00ff41' },
+    { text: '' },
+    { text: '  whoami           Who is Jakub?', color: '#666' },
+    { text: '  skills           Full tech stack', color: '#666' },
+    { text: '  git log          Work history', color: '#666' },
+    { text: '  ls projects/     Recent projects', color: '#666' },
+    { text: '  neofetch         System info', color: '#666' },
+    { text: '  open github      Open GitHub profile', color: '#666' },
+    { text: '  open linkedin    Open LinkedIn', color: '#666' },
+    { text: '  open resume      Open resume PDF', color: '#666' },
+    { text: '  contact          Jump to contact form', color: '#666' },
+    { text: '  clear            Clear terminal', color: '#666' },
+    { text: '  exit             Close terminal', color: '#666' },
+    { text: '' },
+];
+
+const NEOFETCH = [
+    { text: '' },
+    { text: '        ██╗ ██████╗ ', color: '#00ff41' },
+    { text: '        ██║██╔═══██╗         jakub@portfolio', color: '#00ff41' },
+    { text: '        ██║██║   ██║         ───────────────', color: '#00ff41' },
+    { text: '   ██   ██║██║   ██║         Role:  Full-Stack & Mobile Developer', color: '#00ff41' },
+    { text: '   ╚█████╔╝╚██████╔╝         Stack: Kotlin · Swift · JS · Node.js', color: '#00ff41' },
+    { text: '    ╚════╝  ╚═════╝          Time:  3+ years shipping real products', color: '#00ff41' },
+    { text: '                             Apps:  Android · iOS · Web', color: '#00ff41' },
+    { text: `                             Hub:   github.com/Olszewski-Jakub`, color: '#4fc3f7' },
+    { text: '' },
+    { text: '   ████ ████ ████ ████ ████ ████ ████', color: '#00ff41' },
+    { text: '' },
+];
+
+const buildCommands = (addLines, setLines, onClose) => ({
+    help: () => addLines(HELP),
+
+    whoami: () => addLines([
+        { text: `  Name      Jakub Olszewski`, color: '#00ff41' },
+        { text: `  Roles     ${Bio.roles.join(' · ')}`, color: '#00ff41' },
+        { text: `  GitHub    ${Bio.github}`, color: '#4fc3f7' },
+        { text: `  LinkedIn  ${Bio.linkedin}`, color: '#4fc3f7' },
+        { text: '' },
+        { text: `  ${Bio.description}`, color: '#555' },
+        { text: '' },
+    ]),
+
+    skills: () => addLines([
+        { text: '  ┌─ Mobile ──────────────────────────────────────────┐', color: '#333' },
+        { text: '  │  Kotlin (Jetpack Compose)   Swift (SwiftUI)       │', color: '#00ff41' },
+        { text: '  ├─ Backend ─────────────────────────────────────────┤', color: '#333' },
+        { text: '  │  Node.js · REST APIs · Firebase · PostgreSQL      │', color: '#00ff41' },
+        { text: '  ├─ Frontend ────────────────────────────────────────┤', color: '#333' },
+        { text: '  │  React · Styled Components · Framer Motion        │', color: '#00ff41' },
+        { text: '  ├─ Tools ───────────────────────────────────────────┤', color: '#333' },
+        { text: '  │  Git · Docker · CI/CD · Figma                     │', color: '#00ff41' },
+        { text: '  └────────────────────────────────────────────────────┘', color: '#333' },
+        { text: '' },
+    ]),
+
+    'git log': () => addLines([
+        { text: '  commit a3f91c2  (HEAD -> main, origin/main)', color: '#f9a825' },
+        { text: '  Author: Jakub Olszewski', color: '#00ff41' },
+        { text: '  Date:   2024 — Present', color: '#555' },
+        { text: '  » Mobile Developer — production apps, real users', color: '#00ff41' },
+        { text: '' },
+        { text: '  commit b22e1d0', color: '#f9a825' },
+        { text: '  Date:   2023 — 2024', color: '#555' },
+        { text: '  » Android Developer — Kotlin, MVVM, Firebase', color: '#00ff41' },
+        { text: '' },
+        { text: '  commit c11f4a9', color: '#f9a825' },
+        { text: '  Date:   2022 — 2023', color: '#555' },
+        { text: '  » Backend Developer — APIs, databases, CI/CD', color: '#00ff41' },
+        { text: '' },
+        { text: '  → Full history at #experience on the portfolio', color: '#4fc3f7' },
+        { text: '' },
+    ]),
+
+    'ls projects/': () => addLines([
+        { text: '  drwxr-xr-x  Fitness Tracking App      Kotlin · Firebase · ML Kit', color: '#00ff41' },
+        { text: '  drwxr-xr-x  iOS Wallet App            Swift · SwiftUI · Core Data', color: '#00ff41' },
+        { text: '  drwxr-xr-x  E-Commerce Platform       Node.js · React · PostgreSQL', color: '#00ff41' },
+        { text: '  drwxr-xr-x  REST API Gateway          Node.js · Docker · Redis', color: '#00ff41' },
+        { text: '' },
+        { text: `  12+ projects total — scroll to #projects for details`, color: '#4fc3f7' },
+        { text: '' },
+    ]),
+
+    neofetch: () => addLines(NEOFETCH),
+
+    'open github': () => {
+        window.open(Bio.github, '_blank', 'noopener');
+        addLines([{ text: `  Opening ${Bio.github}`, color: '#4fc3f7' }, { text: '' }]);
+    },
+
+    'open linkedin': () => {
+        window.open(Bio.linkedin, '_blank', 'noopener');
+        addLines([{ text: `  Opening ${Bio.linkedin}`, color: '#4fc3f7' }, { text: '' }]);
+    },
+
+    'open resume': () => {
+        window.open(Bio.resume, '_blank', 'noopener');
+        addLines([{ text: '  Opening resume PDF...', color: '#4fc3f7' }, { text: '' }]);
+    },
+
+    contact: () => {
+        onClose();
+        setTimeout(() => document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' }), 350);
+        addLines([{ text: '  Redirecting to contact form...', color: '#4fc3f7' }, { text: '' }]);
+    },
+
+    clear: () => setLines([]),
+
+    exit:  () => onClose(),
+    quit:  () => onClose(),
+});
+
+/* ─── Component ─── */
+
+const Terminal = ({ onClose }) => {
+    const [lines, setLines]       = useState([]);
+    const [input, setInput]       = useState('');
+    const [cmdHistory, setCmdHistory] = useState([]);
+    const [histIdx, setHistIdx]   = useState(-1);
+    const [booting, setBooting]   = useState(true);
+    const bodyRef  = useRef(null);
+    const inputRef = useRef(null);
+
+    const scrollBottom = useCallback(() => {
+        requestAnimationFrame(() => {
+            if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+        });
+    }, []);
+
+    const addLines = useCallback((newLines) => {
+        setLines(prev => [...prev, ...newLines]);
+        scrollBottom();
+    }, [scrollBottom]);
+
+    /* Boot sequence */
+    useEffect(() => {
+        let alive = true;
+        (async () => {
+            for (let i = 0; i < BOOT.length; i++) {
+                await new Promise(r => setTimeout(r, i === 0 ? 60 : 160));
+                if (!alive) return;
+                setLines(prev => [...prev, BOOT[i]]);
+                scrollBottom();
+            }
+            setBooting(false);
+            setTimeout(() => inputRef.current?.focus(), 60);
+        })();
+        return () => { alive = false; };
+    }, [scrollBottom]);
+
+    /* Command execution */
+    const execute = useCallback((raw) => {
+        const cmd = raw.trim().toLowerCase();
+        addLines([{ text: `${PROMPT_STR}${raw}`, color: '#00ff41' }]);
+        if (!cmd) return;
+
+        const commands = buildCommands(addLines, setLines, onClose);
+        const handler = commands[cmd];
+
+        if (handler) {
+            handler();
+        } else {
+            addLines([
+                { text: `  command not found: ${raw}`, color: '#ff5252' },
+                { text: "  Type 'help' for available commands.", color: '#555' },
+                { text: '' },
+            ]);
+        }
+    }, [addLines, onClose]);
+
+    const onKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            const val = input;
+            if (val.trim()) setCmdHistory(h => [val, ...h]);
+            setHistIdx(-1);
+            setInput('');
+            execute(val);
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setHistIdx(i => {
+                const next = Math.min(i + 1, cmdHistory.length - 1);
+                setInput(cmdHistory[next] ?? '');
+                return next;
+            });
+        } else if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setHistIdx(i => {
+                const next = Math.max(i - 1, -1);
+                setInput(next === -1 ? '' : (cmdHistory[next] ?? ''));
+                return next;
+            });
+        } else if (e.key === 'Escape') {
+            onClose();
+        }
+    };
+
+    return (
+        <Overlay onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+            <Window onClick={() => inputRef.current?.focus()}>
+                <TitleBar>
+                    <TrafficDot $color="#ff5f57" onClick={onClose} title="Close" />
+                    <TrafficDot $color="#ffbd2e" title="Minimise" />
+                    <TrafficDot $color="#28c840" title="Maximise" />
+                    <TitleText>jakub@portfolio — bash — 80×24</TitleText>
+                </TitleBar>
+
+                <Body ref={bodyRef}>
+                    {lines.map((l, i) => (
+                        <Line key={i} $color={l.color}>{l.text}</Line>
+                    ))}
+
+                    {!booting && (
+                        <InputRow>
+                            <Prompt>{PROMPT_STR}</Prompt>
+                            <TermInput
+                                ref={inputRef}
+                                value={input}
+                                onChange={e => setInput(e.target.value)}
+                                onKeyDown={onKeyDown}
+                                spellCheck={false}
+                                autoComplete="off"
+                                autoCorrect="off"
+                                autoCapitalize="off"
+                            />
+                            <Cursor />
+                        </InputRow>
+                    )}
+                </Body>
+            </Window>
+        </Overlay>
+    );
+};
+
+export default Terminal;

--- a/src/components/Terminal/index.js
+++ b/src/components/Terminal/index.js
@@ -16,6 +16,13 @@ const Overlay = styled.div`
     align-items: center;
     justify-content: center;
     backdrop-filter: blur(6px);
+
+    @media (max-width: 600px) {
+        align-items: stretch;
+        justify-content: stretch;
+        background: #0d120d;
+        backdrop-filter: none;
+    }
 `;
 
 const Window = styled.div`
@@ -47,6 +54,13 @@ const Window = styled.div`
         pointer-events: none;
         z-index: 10;
         border-radius: 12px;
+    }
+
+    @media (max-width: 600px) {
+        width: 100vw;
+        height: 100dvh;
+        border-radius: 0;
+        &::after { border-radius: 0; }
     }
 `;
 
@@ -97,6 +111,11 @@ const Body = styled.div`
     &::-webkit-scrollbar-thumb {
         background: rgba(0, 255, 65, 0.15);
         border-radius: 2px;
+    }
+
+    @media (max-width: 600px) {
+        font-size: 12px;
+        padding: 12px 14px 8px;
     }
 `;
 

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -9,7 +9,7 @@ export const Bio = {
     "Backend Developer"
   ],
   description:
-    "I am a motivated and versatile individual, always eager to take on new challenges. With a passion for learning I am dedicated to delivering high-quality results. With a positive attitude and a growth mindset, I am ready to make a meaningful contribution and achieve great things.",
+    "I build mobile apps and backend systems that combine clean architecture with intuitive user experiences. Specialising in Android, iOS, and full-stack development — I turn ideas into polished, production-ready products.",
   github: "https://github.com/Olszewski-Jakub",
   resume:
     "https://drive.google.com/file/d/1Mc8z4KKP4jYNVINUufJUJesAkpjKWGee/view?usp=sharing",

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -10,6 +10,11 @@ export const Bio = {
   ],
   description:
     "I build mobile apps and backend systems that combine clean architecture with intuitive user experiences. Specialising in Android, iOS, and full-stack development — I turn ideas into polished, production-ready products.",
+  stats: [
+    { value: 12, suffix: "+", label: "Projects Built" },
+    { value: 20, suffix: "+", label: "Technologies" },
+    { value: 3,  suffix: "+", label: "Years Coding"  },
+  ],
   github: "https://github.com/Olszewski-Jakub",
   resume:
     "https://drive.google.com/file/d/1Mc8z4KKP4jYNVINUufJUJesAkpjKWGee/view?usp=sharing",

--- a/src/hooks/useSmoothScroll.js
+++ b/src/hooks/useSmoothScroll.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import Lenis from 'lenis';
+
+export default function useSmoothScroll() {
+    useEffect(() => {
+        const lenis = new Lenis({
+            duration: 1.2,
+            easing: t => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+            smoothWheel: true,
+            syncTouch: false,
+        });
+
+        let rafId;
+        const raf = time => {
+            lenis.raf(time);
+            rafId = requestAnimationFrame(raf);
+        };
+        rafId = requestAnimationFrame(raf);
+
+        return () => {
+            cancelAnimationFrame(rafId);
+            lenis.destroy();
+        };
+    }, []);
+}

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -3,10 +3,6 @@ import { createGlobalStyle } from 'styled-components';
 const GlobalStyles = createGlobalStyle`
   /* Fonts and base resets remain in App.css */
 
-  html {
-    scroll-behavior: smooth;
-  }
-
   body {
     margin: 0 !important;
     padding: 0;

--- a/src/utils/Themes.js
+++ b/src/utils/Themes.js
@@ -40,6 +40,7 @@ export const lightTheme = {
     text_primary: "#0F172A",       // slate-900
     text_secondary: "#475569",     // slate-600
     card: "#FFFFFF",
+    card_light: "#EFF2F7",         // slightly darker than bgLight for contrast
     button: "#2563EB",
     white: "#FFFFFF",
     black: "#000000",


### PR DESCRIPTION
- Hero: gradient text for name, dual CTA buttons (Resume + Contact Me),
  animated glow-pulse border on profile image, removed dated clip-path
- Navbar: scroll progress bar (3px fixed bar below nav), replaced generic
  DiCssdeck logo with J.O. initials badge with gradient background
- SectionTitle: shared component with SectionLabel pill chips and gradient
  underline — applied consistently across all sections (Skills, Experience,
  Education, Projects, Certificates, Contact)
- Background alternation: Experience, Certificates, and Contact sections now
  use card_light to create a zebra-stripe rhythm between sections
- Skills: converted from flat 2-column grid to tabbed layout with category
  icons (FaCode, FaServer, FaMobileAlt, FaTools) and AnimatePresence transitions
- ProjectCards: hover overlay reveal ("View Details →"), min-height instead of
  fixed height, improved tag styling with primary color fill + border
- Contact: two-column layout with social info cards sidebar (LinkedIn, GitHub,
  Location) beside the form; improved submit button gradient
- Footer: SVG wave divider above footer for smooth transition from last section
- Animations: migrated Experience, Education, Certificates, Contact, Projects
  headings to Framer Motion whileInView (was CSS fadeIn on mount)
- Themes: added missing card_light token to lightTheme (#EFF2F7)

https://claude.ai/code/session_01AHK3sSMonZHRnUy8oXQFx2